### PR TITLE
Setup Controller Boilerplate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,23 +23,31 @@ codegen:
 check_codegen: codegen
 	@git diff --exit-code
 
-.PHONY: deploy_dev_crds
-deploy_dev_crds:
+.PHONY: run_controller_local
+run_controller_local:
+	go run ./cmd/controller -kubeconfig=${HOME}/.kube/config
+
+.PHONY: deploy_crds_dev
+deploy_crds_dev:
 	kubectl apply -f ./helm/crds
 
 .PHONY: deploy_dev
-deploy_dev: deploy_dev_crds
+deploy_dev: deploy_crds_dev
 	helm template \
 		--values helm/values.yaml \
 		--set image.devRef=ko://github.com/jlevesy/kudo/cmd/controller \
 		kudo-dev ./helm | KO_DOCKER_REPO=$(KO_DOCKER_REPO) ko apply -B -t dev -f -
 
-.PHONY: create_dev_cluster
-create_dev_cluster:
+.PHONY: logs_dev
+logs_dev:
+	kubectl logs -f -l app.kubernetes.io/name=kudo
+
+.PHONY: create_cluster_dev
+create_cluster_dev:
 	k3d cluster create \
 		--image="rancher/k3s:v1.24.3-k3s1" \
 		kudo-dev
 
-.PHONY: delete_dev_cluster
-delete_dev_cluster:
+.PHONY: delete_cluster_dev
+delete_cluster_dev:
 	k3d cluster delete kudo-dev

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -2,36 +2,32 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"golang.org/x/sync/errgroup"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 
 	clientset "github.com/jlevesy/kudo/pkg/generated/clientset/versioned"
-	"github.com/jlevesy/kudo/pkg/webhooksupport"
-	"github.com/jlevesy/kudo/webhook/escalation"
+	"github.com/jlevesy/kudo/webhook"
 )
 
 var (
 	masterURL  string
 	kubeconfig string
 
-	whCfg webhookConfig
+	webhookConfig webhook.ServerConfig
 )
 
 func main() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
-	flag.StringVar(&whCfg.certPath, "webhook_cert", "", "Path to webhook TLS cert")
-	flag.StringVar(&whCfg.keyPath, "webhook_key", "", "Path to webhook TLS key")
-	flag.StringVar(&whCfg.addr, "webhook_addr", ":8080", "Webhook listening address")
+	flag.StringVar(&webhookConfig.CertPath, "webhook_cert", "", "Path to webhook TLS cert")
+	flag.StringVar(&webhookConfig.KeyPath, "webhook_key", "", "Path to webhook TLS key")
+	flag.StringVar(&webhookConfig.Addr, "webhook_addr", ":8080", "Webhook listening address")
 	klog.InitFlags(nil)
 
 	flag.Parse()
@@ -53,86 +49,11 @@ func main() {
 
 	group, ctx := errgroup.WithContext(ctx)
 
-	group.Go(func() error { return runWebhookHandler(ctx, kudoClientSet, whCfg) })
+	group.Go(func() error { return webhook.RunServer(ctx, kudoClientSet, webhookConfig) })
 
 	if err := group.Wait(); err != nil {
 		klog.Error("Controller reported an error")
 	}
 
 	klog.Info("Exited kudo controller")
-}
-
-type webhookConfig struct {
-	certPath string
-	keyPath  string
-	addr     string
-}
-
-func runWebhookHandler(ctx context.Context, kudoClientSet clientset.Interface, cfg webhookConfig) error {
-	var (
-		mux = http.NewServeMux()
-		srv = &http.Server{
-			Addr:           cfg.addr,
-			Handler:        mux,
-			ReadTimeout:    5 * time.Second,
-			WriteTimeout:   5 * time.Second,
-			MaxHeaderBytes: 1 << 20, // 1048576
-
-		}
-		serveFailed = make(chan error)
-	)
-
-	webhookHandler := escalation.NewWebhookHandler(
-		kudoClientSet.K8sV1alpha1().EscalationPolicies(),
-	)
-
-	mux.Handle("/v1alpha1/escalations", webhooksupport.MustPost(webhookHandler))
-
-	go func() {
-		var err error
-
-		if cfg.certPath == "" || cfg.keyPath == "" {
-			klog.InfoS("Starting INSECURE webhook server over HTTP", "addr", srv.Addr)
-
-			err = srv.ListenAndServe()
-		} else {
-			klog.InfoS(
-				"Starting webhook server over HTTPS",
-				"addr",
-				srv.Addr,
-				"cert_path",
-				cfg.certPath,
-				"key_path",
-				cfg.keyPath,
-			)
-
-			err = srv.ListenAndServeTLS(cfg.certPath, cfg.keyPath)
-		}
-
-		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			// If the server fails to serve, we need to stop.
-			serveFailed <- err
-		}
-	}()
-
-	select {
-	case err := <-serveFailed:
-		klog.ErrorS(err, "Server exited reporting an error")
-		return err
-	case <-ctx.Done():
-		klog.Info("Main context exited, gracefully stoping server")
-	}
-
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	if err := srv.Shutdown(shutdownCtx); err != nil {
-		klog.ErrorS(err, "shutdown reported an error, closing the server")
-
-		_ = srv.Close()
-	}
-
-	klog.Info("Webhook server exited")
-
-	return nil
 }

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -6,12 +6,17 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"golang.org/x/sync/errgroup"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 
+	kudov1alpha1 "github.com/jlevesy/kudo/pkg/apis/k8s.kudo.dev/v1alpha1"
+	"github.com/jlevesy/kudo/pkg/controllersupport"
 	clientset "github.com/jlevesy/kudo/pkg/generated/clientset/versioned"
+	kudoinformers "github.com/jlevesy/kudo/pkg/generated/informers/externalversions"
 	"github.com/jlevesy/kudo/webhook"
 )
 
@@ -21,6 +26,8 @@ var (
 
 	webhookConfig webhook.ServerConfig
 )
+
+const defaultInformerResyncInterval = 30 * time.Second
 
 func main() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
@@ -47,13 +54,61 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
+	var (
+		kudoInformerFactory = kudoinformers.NewSharedInformerFactory(kudoClientSet, defaultInformerResyncInterval)
+		escalationsInformer = kudoInformerFactory.K8s().V1alpha1().Escalations().Informer()
+		escalationHandler   = controllersupport.NewQueuedEventHandler[kudov1alpha1.Escalation](
+			&logHandler{},
+			kudov1alpha1.KindEscalation,
+			2,
+		)
+	)
+
+	escalationsInformer.AddEventHandler(escalationHandler)
+
 	group, ctx := errgroup.WithContext(ctx)
 
-	group.Go(func() error { return webhook.RunServer(ctx, kudoClientSet, webhookConfig) })
+	klog.Info("Starting informers, waiting for them to warm up...")
+
+	kudoInformerFactory.Start(ctx.Done())
+
+	if ok := cache.WaitForCacheSync(ctx.Done(), escalationsInformer.HasSynced); !ok {
+		klog.Fatal("Cache sync failed, exiting...")
+	}
+
+	klog.Info("Informers warmed up, starting controller...")
+
+	group.Go(func() error {
+		return webhook.RunServer(ctx, kudoClientSet, webhookConfig)
+	})
+
+	group.Go(func() error {
+		escalationHandler.Run(ctx)
+		return nil
+	})
+
+	klog.Info("Controller up and running!")
 
 	if err := group.Wait(); err != nil {
 		klog.Error("Controller reported an error")
 	}
 
 	klog.Info("Exited kudo controller")
+}
+
+type logHandler struct{}
+
+func (logHandler) OnAdd(escalation *kudov1alpha1.Escalation) error {
+	klog.Info("RECEIVED AN ADD ==>", escalation.Name)
+	return nil
+}
+
+func (logHandler) OnUpdate(oldEsc, newEsc *kudov1alpha1.Escalation) error {
+	klog.Info("RECEIVED AN UPDATE ==>", oldEsc.Name)
+	return nil
+}
+
+func (logHandler) OnDelete(esc *kudov1alpha1.Escalation) error {
+	klog.Info("RECEIVED A DELETE ==>", esc.Name)
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3
 	k8s.io/client-go v0.24.3

--- a/go.sum
+++ b/go.sum
@@ -360,6 +360,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -30,6 +30,13 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "helm.imageName" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "-webhook_cert"
+            - "/var/run/certs/tls.crt"
+            - "-webhook_key"
+            - "/var/run/certs/tls.key"
+            - "-webhook_addr"
+            - ":443"
           ports:
             - name: https
               containerPort: 443

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -8,6 +8,7 @@ rules:
     - "k8s.kudo.dev"
   resources:
     - "escalationpolicies"
+    - "escalations"
   verbs:
     - "get"
     - "list"

--- a/pkg/controllersupport/handler.go
+++ b/pkg/controllersupport/handler.go
@@ -1,0 +1,169 @@
+package controllersupport
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+// ErrTransientError can be returned by an EventHandler to trigger a retry.
+var ErrTransientError = errors.New("transient error")
+
+// EventHandler represents a object that handles mutation event  a k8s object.
+// It is based on k8s-clen cache.EventHandler.
+type EventHandler[T any] interface {
+	OnAdd(obj *T) error
+	OnUpdate(oldObj, newObj *T) error
+	OnDelete(obj *T) error
+}
+
+// QueuedEventHandler implements cache.EventHandler over a workqueue.
+// It also handles the type conversion of updated objects to pass them down to an EventHandler.
+type QueuedEventHandler[T any] struct {
+	workqueue workqueue.RateLimitingInterface
+	name      string
+	workers   int
+
+	handler EventHandler[T]
+}
+
+// NewQueuedEventHandler returns a queued event handler
+func NewQueuedEventHandler[T any](handler EventHandler[T], name string, workers int) *QueuedEventHandler[T] {
+	return &QueuedEventHandler[T]{
+		workqueue: workqueue.NewNamedRateLimitingQueue(
+			workqueue.DefaultControllerRateLimiter(),
+			name,
+		),
+
+		handler: handler,
+		workers: workers,
+		name:    name,
+	}
+}
+
+// OnAdd enqueues an add event.
+func (h *QueuedEventHandler[T]) OnAdd(obj any) {
+	h.workqueue.Add(queueEvent{kind: kindAdd, object: obj})
+}
+
+// OnUpdate enqueues an update event.
+func (h *QueuedEventHandler[T]) OnUpdate(oldObj, newObj any) {
+	h.workqueue.Add(queueEvent{kind: kindUpdate, oldObj: oldObj, newObj: newObj})
+}
+
+// OnDelete enqueues an update event.
+func (h *QueuedEventHandler[T]) OnDelete(obj any) {
+	h.workqueue.Add(queueEvent{kind: kindDelete, object: obj})
+}
+
+// Run starts workers and waits until completion.
+func (h *QueuedEventHandler[T]) Run(ctx context.Context) {
+	defer utilruntime.HandleCrash()
+	defer h.workqueue.ShutDown()
+
+	klog.InfoS("Starting workers for handler", "name", h.name, "total", h.workers)
+
+	for i := 0; i < h.workers; i++ {
+		go wait.UntilWithContext(ctx, h.runWorker, time.Second)
+	}
+
+	klog.InfoS("Started workers for handler", "name", h.name)
+
+	<-ctx.Done()
+
+	klog.InfoS("Shutting down workers for handler", "name", h.name)
+}
+
+func (h *QueuedEventHandler[T]) runWorker(ctx context.Context) {
+	for h.processItem(ctx) {
+	}
+}
+
+func (h *QueuedEventHandler[T]) processItem(ctx context.Context) bool {
+	obj, shutdown := h.workqueue.Get()
+
+	if shutdown {
+		return false
+	}
+
+	defer h.workqueue.Done(obj)
+
+	event, ok := obj.(queueEvent)
+
+	if !ok {
+		h.workqueue.Forget(obj)
+		return true
+	}
+
+	var err error
+
+	switch event.kind {
+	case kindAdd:
+		typedObject, ok := event.object.(*T)
+		if !ok {
+			h.workqueue.Forget(obj)
+			return true
+		}
+
+		err = h.handler.OnAdd(typedObject)
+	case kindUpdate:
+		typedOldObject, okOld := event.oldObj.(*T)
+		typedNewObject, okNew := event.newObj.(*T)
+
+		if !okOld || !okNew {
+			h.workqueue.Forget(obj)
+			return true
+		}
+
+		err = h.handler.OnUpdate(typedOldObject, typedNewObject)
+
+	case kindDelete:
+		typedObject, ok := event.object.(*T)
+		if !ok {
+			h.workqueue.Forget(obj)
+			return true
+		}
+
+		err = h.handler.OnDelete(typedObject)
+
+	default:
+		h.workqueue.Forget(obj)
+		return true
+	}
+
+	if errors.Is(err, ErrTransientError) {
+		klog.ErrorS(err, "handler reported a transient error, requeuing...", "name", h.name)
+		h.workqueue.AddRateLimited(obj)
+		return true
+	}
+
+	if err != nil {
+		klog.ErrorS(err, "handler reported an error", "name", h.name)
+	}
+
+	h.workqueue.Forget(obj)
+
+	return true
+}
+
+type queueEventKind uint8
+
+const (
+	// forces assignation of an explicit value when using this enumeration.
+	kindUnknown queueEventKind = iota //nolint:deadcode,varcheck
+	kindAdd
+	kindUpdate
+	kindDelete
+)
+
+type queueEvent struct {
+	kind   queueEventKind
+	object any
+	oldObj any
+	newObj any
+}

--- a/pkg/controllersupport/handler_test.go
+++ b/pkg/controllersupport/handler_test.go
@@ -1,0 +1,84 @@
+package controllersupport_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jlevesy/kudo/pkg/controllersupport"
+	"github.com/jlevesy/kudo/pkg/generics"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueuedEventHandler_HandlesEvent(t *testing.T) {
+	var (
+		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+		handler     = testHandler{
+			wantCalls: 4,
+			done:      cancel,
+		}
+		eventHandler = controllersupport.NewQueuedEventHandler[int](
+			&handler,
+			"test",
+			1,
+		)
+	)
+
+	defer cancel()
+
+	// Enqueue some calls.
+	eventHandler.OnAdd(generics.Ptr(4))
+	// Make sure that invalid calls are ignored...
+	eventHandler.OnAdd(nil)
+	eventHandler.OnUpdate(generics.Ptr(4), generics.Ptr(4))
+	eventHandler.OnUpdate(nil, nil)
+	eventHandler.OnDelete(generics.Ptr(4))
+	eventHandler.OnDelete(nil)
+
+	// Run the queue until completion.
+	eventHandler.Run(ctx)
+
+	assert.True(t, handler.isComplete())
+}
+
+type testHandler struct {
+	addReceived    int
+	updateReceived int
+	deleteReceived int
+
+	wantCalls int
+	done      func()
+}
+
+func (h *testHandler) OnAdd(*int) error {
+	v := h.addReceived
+	h.addReceived++
+	// On first call, return transient error to test the retry behavior.
+	if v == 0 {
+		return controllersupport.ErrTransientError
+	}
+	h.call()
+	return nil
+}
+
+func (h *testHandler) OnUpdate(_, _ *int) error {
+	h.updateReceived++
+	h.call()
+	return nil
+}
+
+func (h *testHandler) OnDelete(*int) error {
+	h.deleteReceived++
+	h.call()
+	return nil
+}
+
+func (h *testHandler) call() {
+	if h.isComplete() {
+		h.done()
+	}
+}
+
+func (h *testHandler) isComplete() bool {
+	return h.wantCalls == (h.addReceived + h.updateReceived + h.deleteReceived)
+}

--- a/webhook/run.go
+++ b/webhook/run.go
@@ -1,0 +1,89 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	clientset "github.com/jlevesy/kudo/pkg/generated/clientset/versioned"
+	"github.com/jlevesy/kudo/pkg/webhooksupport"
+	"github.com/jlevesy/kudo/webhook/escalation"
+)
+
+type ServerConfig struct {
+	CertPath string
+	KeyPath  string
+	Addr     string
+}
+
+func RunServer(ctx context.Context, kudoClientSet clientset.Interface, cfg ServerConfig) error {
+	var (
+		mux = http.NewServeMux()
+		srv = &http.Server{
+			Addr:           cfg.Addr,
+			Handler:        mux,
+			ReadTimeout:    5 * time.Second,
+			WriteTimeout:   5 * time.Second,
+			MaxHeaderBytes: 1 << 20, // 1048576
+
+		}
+		serveFailed = make(chan error)
+	)
+
+	webhookHandler := escalation.NewWebhookHandler(
+		kudoClientSet.K8sV1alpha1().EscalationPolicies(),
+	)
+
+	mux.Handle("/v1alpha1/escalations", webhooksupport.MustPost(webhookHandler))
+
+	go func() {
+		var err error
+
+		if cfg.CertPath == "" || cfg.KeyPath == "" {
+			klog.InfoS("Starting INSECURE webhook server over HTTP", "addr", srv.Addr)
+
+			err = srv.ListenAndServe()
+		} else {
+			klog.InfoS(
+				"Starting webhook server over HTTPS",
+				"addr",
+				srv.Addr,
+				"cert_path",
+				cfg.CertPath,
+				"key_path",
+				cfg.KeyPath,
+			)
+
+			err = srv.ListenAndServeTLS(cfg.CertPath, cfg.KeyPath)
+		}
+
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			// If the server fails to serve, we need to stop.
+			serveFailed <- err
+		}
+	}()
+
+	select {
+	case err := <-serveFailed:
+		klog.ErrorS(err, "Server exited reporting an error")
+		return err
+	case <-ctx.Done():
+		klog.Info("Main context exited, gracefully stoping server")
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		klog.ErrorS(err, "shutdown reported an error, closing the server")
+
+		_ = srv.Close()
+	}
+
+	klog.Info("Webhook server exited")
+
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?

This PR updates the controller so that it serves the webhook and concurently handle resource events for `Escalation`. At that point it only logs events. Implementation of the logic will be done at a later point.

The changset includes:
- Some makefile improvents
- Controller can now be configured and started locally using `make run_local`
- Some plumbing regarding k8s controller tooling integration, to keep the code clean. I went crazy on generics, but managed to fall back on my leg. yay.