### PR TITLE
Day to day life improvements + use lister for webhook handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,17 @@ check_codegen: codegen
 run_controller_local:
 	go run ./cmd/controller -kubeconfig=${HOME}/.kube/config
 
+.PHONY: run_dev
+run_dev: create_cluster_dev deploy_dev create_test_user_dev deploy_kudo_resources_dev
+
 .PHONY: deploy_crds_dev
 deploy_crds_dev:
 	kubectl apply -f ./helm/crds
+
+.PHONY: deploy_kudo_resources_dev
+deploy_kudo_resources_dev:
+	kubectl apply -f ./examples/escalation-rbac.yaml
+	kubectl apply -f ./examples/escalation-policy.yaml
 
 .PHONY: deploy_dev
 deploy_dev: deploy_crds_dev
@@ -49,5 +57,22 @@ create_cluster_dev:
 		kudo-dev
 
 .PHONY: delete_cluster_dev
-delete_cluster_dev:
+delete_cluster_dev: delete_test_user_dev
 	k3d cluster delete kudo-dev
+
+.PHONY: create_test_user_dev
+create_test_user_dev:
+	./hack/create-test-user.sh
+
+.PHONY: delete_test_user_dev
+delete_test_user_dev:
+	-kubectl config delete-user kudo-test-user
+	-kubectl config delete-context kudo-test-user
+
+.PHONY: use_admin_user_dev
+use_admin_user_dev:
+	kubectl config use-context k3d-kudo-dev
+
+.PHONY: use_test_user_dev
+use_test_user_dev:
+	kubectl config use-context kudo-test-user

--- a/examples/escalation-policy.yaml
+++ b/examples/escalation-policy.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   subjects: # (required) who has the right to trigger this escalation.
     - kind: Group
-      name: squad-a@group.com
+      name: kudo-test-group
   challenges: # (optional) list of challenges being applied when esclating.
     - kind: TwoFactor
       reviewers:

--- a/examples/escalation-rbac.yaml
+++ b/examples/escalation-rbac.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: can-escalate
+rules:
+- apiGroups:
+    - "k8s.kudo.dev"
+  resources:
+    - "escalations"
+  verbs:
+    - "create"
+    - "get"
+    - "list"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: can-escalate
+subjects:
+- kind: Group
+  name: kudo-test-group
+roleRef:
+  kind: ClusterRole
+  name: can-escalate
+  apiGroup: rbac.authorization.k8s.io

--- a/hack/create-test-user.sh
+++ b/hack/create-test-user.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+mkdir /tmp/kudo-dev
+pushd /tmp/kudo-dev
+
+openssl genrsa -out kudo-test-user.key 2048
+openssl req -new -key kudo-test-user.key -out kudo-test-user.csr -subj "/CN=kudo-test-user/O=kudo-test-group"
+
+cat <<EOF | kubectl apply -f -
+apiVersion: certificates.k8s.io/v1
+kind: CertificateSigningRequest
+metadata:
+  name: kudo-test-user
+spec:
+  request: $(cat ./kudo-test-user.csr | base64)
+  signerName: kubernetes.io/kube-apiserver-client
+  expirationSeconds: 86400
+  usages:
+  - client auth
+EOF
+
+kubectl certificate approve kudo-test-user
+kubectl get csr kudo-test-user -o jsonpath='{.status.certificate}'| base64 -d > kudo-test-user.crt
+
+kubectl \
+	config set-credentials kudo-test-user \
+	--embed-certs=true \
+	--client-certificate=./kudo-test-user.crt \
+	--client-key=./kudo-test-user.key
+kubectl \
+  config set-context kudo-test-user \
+  --cluster=k3d-kudo-dev \
+	--user=kudo-test-user
+popd
+
+rm -rf /tmp/kudo-dev

--- a/webhook/escalation/webhook.go
+++ b/webhook/escalation/webhook.go
@@ -1,7 +1,6 @@
 package escalation
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -35,7 +34,7 @@ var (
 )
 
 type EscalationPoliciesGetter interface {
-	Get(ctx context.Context, name string, opts metav1.GetOptions) (*v1alpha1.EscalationPolicy, error)
+	Get(name string) (*v1alpha1.EscalationPolicy, error)
 }
 
 type WebhookHandler struct {
@@ -126,11 +125,7 @@ func (h *WebhookHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	}
 
-	policy, err := h.policiesGetter.Get(
-		r.Context(),
-		escalation.Spec.PolicyName,
-		metav1.GetOptions{},
-	)
+	policy, err := h.policiesGetter.Get(escalation.Spec.PolicyName)
 
 	switch {
 	case errors.IsNotFound(err):
@@ -138,7 +133,7 @@ func (h *WebhookHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 			"User submitted an escalation request refering to a policy that doesn't exist",
 			usernameAndPolicyTags(
 				review.Request.UserInfo.Username,
-				"unknown",
+				escalation.Spec.PolicyName,
 			)...,
 		)
 

--- a/webhook/run.go
+++ b/webhook/run.go
@@ -8,7 +8,6 @@ import (
 
 	"k8s.io/klog/v2"
 
-	clientset "github.com/jlevesy/kudo/pkg/generated/clientset/versioned"
 	"github.com/jlevesy/kudo/pkg/webhooksupport"
 	"github.com/jlevesy/kudo/webhook/escalation"
 )
@@ -19,7 +18,7 @@ type ServerConfig struct {
 	Addr     string
 }
 
-func RunServer(ctx context.Context, kudoClientSet clientset.Interface, cfg ServerConfig) error {
+func RunServer(ctx context.Context, webhookHandler *escalation.WebhookHandler, cfg ServerConfig) error {
 	var (
 		mux = http.NewServeMux()
 		srv = &http.Server{
@@ -31,10 +30,6 @@ func RunServer(ctx context.Context, kudoClientSet clientset.Interface, cfg Serve
 
 		}
 		serveFailed = make(chan error)
-	)
-
-	webhookHandler := escalation.NewWebhookHandler(
-		kudoClientSet.K8sV1alpha1().EscalationPolicies(),
 	)
 
 	mux.Handle("/v1alpha1/escalations", webhooksupport.MustPost(webhookHandler))


### PR DESCRIPTION
### What does this PR do?

- Change the webhook handler so it uses a lister (k8s client cache) instead of hitting the k8s API
- Add a couple of useful targets for the makefile, and also allow to use a test user without any permissions on the dev env

### How to test this P?

```
make run_dev
make use_test_user_dev

k get pods (you should get kicked)
```