### PR TITLE
Add an e2e test runtime

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,32 @@ jobs:
       - name: Run Unit Tests
         run: make unit_tests
 
+  e2e-tests:
+    name: e2e Test Suite
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: './go.mod'
+          check-latest: true
+          cache: true
+      - name: Install CLI dependencies
+        run: |
+          go install helm.sh/helm/v3/cmd/helm@v3.9.3
+          helm version
+          go install github.com/google/ko@v0.11.2
+          ko version
+          go install github.com/k3d-io/k3d/v5@v5.4.4
+          k3d version
+      - name: Patch /etc/hosts
+        run: |
+          echo "127.0.0.1 kudo-e2e-registry.localhost" | sudo tee -a /etc/hosts
+      - name: Run The e2e Test Suite
+        run: make e2e_tests
+
   release:
     name: Release
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ install_dependencies:
 
 .PHONY: unit_tests
 unit_tests:
-	go test -short -failfast -cover ./...
+	go test -failfast -cover $(shell go list ./... | grep -v e2e)
 
 .PHONY: e2e_tests
 e2e_tests:
-	go test -failfast ./e2e
+	go test -failfast -v ./e2e
 
 .PHONY: codegen
 codegen:

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ install_dependencies:
 unit_tests:
 	go test -short -failfast -cover ./...
 
+.PHONY: e2e_tests
+e2e_tests:
+	go test -failfast ./e2e
+
 .PHONY: codegen
 codegen:
 	@bash ${GOPATH}/pkg/mod/k8s.io/code-generator@v$(CODE_GENERATOR_VERSION)/generate-groups.sh \

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -90,6 +90,10 @@ func main() {
 
 	escalationsInformer.AddEventHandler(escalationController)
 	serveMux.Handle("/v1alpha1/escalations", webhooksupport.MustPost(escalationWebhookHandler))
+	serveMux.HandleFunc("/healthz", func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		_, _ = rw.Write([]byte("ok"))
+	})
 
 	group, ctx := errgroup.WithContext(ctx)
 

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -1,0 +1,320 @@
+package e2e
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+
+	kudoclientset "github.com/jlevesy/kudo/pkg/generated/clientset/versioned"
+)
+
+const (
+	registryDomain = "kudo-e2e-registry.localhost"
+	imageRef       = registryDomain + ":5000/kudo"
+	k3dClusterName = "kudo-e2e-test"
+)
+
+var (
+	k8sClientset  kubernetes.Interface
+	kudoClientSet kudoclientset.Interface
+
+	debug, _ = strconv.ParseBool(os.Getenv("DEBUG"))
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(run(m))
+}
+
+func run(m *testing.M) int {
+	ctx := context.Background()
+
+	klog.Info("Checking system dependencies")
+	if err := checkBinaries("k3d", "ko", "helm"); err != nil {
+		klog.ErrorS(err, "One or more necessary binaries are not found")
+		return 1
+	}
+
+	if err := checkHostsFile(registryDomain); err != nil {
+		klog.ErrorS(err, "/etc/hosts configuration required")
+		return 1
+	}
+
+	klog.Info("/etc/hosts file properly configured")
+
+	klog.Info("Booting a k3d cluster")
+	if err := hasK3dCluster(ctx, k3dClusterName); err == nil {
+		klog.Info("Found an existing cluster, cleaning it up")
+
+		if err := deleteK3dCluster(ctx, k3dClusterName); err != nil {
+			klog.ErrorS(err, "unable to delete previous k3d cluster")
+			return 1
+		}
+	}
+
+	if err := runK3dCluster(ctx, k3dClusterName); err != nil {
+		klog.ErrorS(err, "Unable to create a k3d cluster")
+		return 1
+	}
+
+	defer func() {
+		klog.Info("Cleaning k3d cluster")
+		if err := deleteK3dCluster(ctx, k3dClusterName); err != nil {
+			klog.ErrorS(err, "Unable to delete a k3d cluster")
+		}
+	}()
+
+	kubeConfigFile, err := getKubeConfig(ctx, k3dClusterName)
+	if err != nil {
+		klog.ErrorS(err, "Unable to retrieve kube config")
+		return 1
+	}
+
+	klog.InfoS("kubeconfig can be found here", "path", kubeConfigFile.Name())
+
+	defer os.Remove(kubeConfigFile.Name())
+
+	klog.Info("Building controller image")
+	if err := buildAndPushImage(ctx); err != nil {
+		klog.ErrorS(err, "Unable to build image")
+		return 1
+	}
+
+	k8sClientset, kudoClientSet, err = buildK8sClientSets(ctx, kubeConfigFile.Name())
+	if err != nil {
+		klog.ErrorS(err, "Unable to build k8s clients")
+		os.Exit(1)
+	}
+
+	klog.Info("Deploying kudo")
+	if err := installKudo(ctx, kubeConfigFile.Name()); err != nil {
+		klog.ErrorS(err, "Unable to install kudo")
+		return 1
+	}
+
+	klog.Info("Runing tests")
+	return m.Run()
+}
+
+func installKudo(ctx context.Context, kubeConfigPath string) error {
+	return execCmd(
+		ctx,
+		execCall{
+			name: "helm",
+			args: []string{
+				"upgrade",
+				"--install",
+				"--kubeconfig=" + kubeConfigPath,
+				"--create-namespace",
+				"--namespace=kudo-e2e",
+				"--set=image.devRef=" + imageRef,
+				"--wait",
+				"--timeout=1m",
+				"kudo-e2e",
+				"../helm",
+			},
+		},
+	)
+}
+
+func buildAndPushImage(ctx context.Context) error {
+	return execCmd(
+		ctx,
+		execCall{
+			name: "ko",
+			env: map[string]string{
+				"KO_DOCKER_REPO": registryDomain + ":5001/kudo",
+			},
+			args: []string{
+				"build",
+				"--bare",
+				"../cmd/controller",
+			},
+		},
+	)
+}
+
+func getKubeConfig(ctx context.Context, clusterName string) (*os.File, error) {
+	kubeConfigFile, err := os.CreateTemp("", "kubeconfig")
+	if err != nil {
+		return nil, err
+	}
+
+	return kubeConfigFile, execCmd(
+		ctx,
+		execCall{
+			name: "k3d",
+			args: []string{
+				"kubeconfig",
+				"write",
+				clusterName,
+				"--output=" + kubeConfigFile.Name(),
+			},
+		},
+	)
+}
+
+func buildK8sClientSets(ctx context.Context, kubeFilePath string) (kubernetes.Interface, kudoclientset.Interface, error) {
+	kubeCfg, err := clientcmd.BuildConfigFromFlags(
+		"",
+		kubeFilePath,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(kubeCfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	kudoClient, err := kudoclientset.NewForConfig(kubeCfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return kubeClient, kudoClient, nil
+}
+
+func runK3dCluster(ctx context.Context, clusterName string) error {
+	return execCmd(
+		ctx,
+		execCall{
+			name: "k3d",
+			args: []string{
+				"cluster",
+				"create",
+				clusterName,
+				"--image=rancher/k3s:v1.24.3-k3s1",
+				fmt.Sprintf("--registry-create=%s:0.0.0.0:5001", registryDomain),
+				"--no-lb",
+				"--kubeconfig-switch-context=false",
+				"--kubeconfig-update-default=false",
+				"--k3s-arg",
+				"--disable=traefik@server:0",
+			},
+		},
+	)
+}
+
+func hasK3dCluster(ctx context.Context, clusterName string) error {
+	return execCmd(
+		ctx,
+		execCall{
+			name: "k3d",
+			args: []string{
+				"cluster",
+				"get",
+				clusterName,
+			},
+		},
+	)
+}
+
+func deleteK3dCluster(ctx context.Context, clusterName string) error {
+	return execCmd(
+		ctx,
+		execCall{
+			name: "k3d",
+			args: []string{
+				"cluster",
+				"delete",
+				clusterName,
+			},
+		},
+	)
+}
+
+type execCall struct {
+	name string
+	args []string
+	env  map[string]string
+}
+
+func execCmd(ctx context.Context, call execCall) error {
+	var (
+		cmd = exec.CommandContext(ctx, call.name, call.args...)
+	)
+
+	cmd.Env = os.Environ()
+
+	for varName, value := range call.env {
+		cmd.Env = append(cmd.Env, varName+"="+value)
+	}
+
+	if debug {
+		klog.Info("Running command: ", cmd.String())
+
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return err
+		}
+		defer stdout.Close()
+
+		stderr, err := cmd.StderrPipe()
+		if err != nil {
+			return err
+		}
+		defer stderr.Close()
+
+		copyDone := make(chan struct{})
+		// Always wait for the stdout copy  to be done at that point.
+		defer func() { <-copyDone }()
+
+		go func() {
+			_, _ = io.Copy(os.Stdout, io.MultiReader(stdout, stderr))
+			close(copyDone)
+		}()
+	}
+
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func checkBinaries(binaries ...string) error {
+	for _, binary := range binaries {
+		path, err := exec.LookPath(binary)
+		if err != nil {
+			return err
+		}
+
+		klog.InfoS("Using binary", "name", binary, "path", path)
+	}
+
+	return nil
+}
+
+func checkHostsFile(registryDomain string) error {
+	file, err := os.Open("/etc/hosts")
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		if strings.Contains(scanner.Text(), registryDomain) && strings.Contains(scanner.Text(), "127.0.0.1") {
+			return nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	return fmt.Errorf("domain %s can't be found in your /etc/hosts file, please configure it to point to 127.0.0.1", registryDomain)
+}

--- a/e2e/some_test.go
+++ b/e2e/some_test.go
@@ -1,0 +1,16 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSomething(t *testing.T) {
+	nodes, err := k8sClientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+
+	t.Log(nodes)
+}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -41,15 +41,30 @@ spec:
             - name: https
               containerPort: 443
               protocol: TCP
-          # TODO(jly): figure this out later.
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: https
+              scheme: HTTPS
+            failureThreshold: 10 # 50seconds to wake up, that would be good.
+            timeoutSeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: https
+              scheme: HTTPS
+            failureThreshold: 3
+            timeoutSeconds: 5
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: https
+              scheme: HTTPS
+            failureThreshold: 3
+            timeoutSeconds: 5
+            periodSeconds: 5
           volumeMounts:
             - name: certs
               mountPath: /var/run/certs

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -46,7 +46,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ include "helm.serviceAccountName" . }}
-  namespace: {{ default .Release.namespace "default" }}
+  namespace: {{ default "default" .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ include "helm.fullname" . }}-controller


### PR DESCRIPTION
### What does this PR do?

- Add support for liveness, readiness probes in both the controller and helm manifests
- Implement an e2e test runtime and a dumb test
- Fix an issue where the controler cluster role binding wasn't created on a specific namepsace
- Try to run the e2e test suite from the CI.

Relates to #8 

### Additional Notes

I was initially not keen to use external CLI tools, and tried to embed everything for a while.
While it has been a bit instructive:

- I faced a dependency hell
- I ended up relying on some unstable APIs.

So went back for external CLIs 😅 