### PR TITLE
Harden RoleBinding detection and detect role binding tampering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 CODE_GENERATOR_VERSION=0.24.3
+COUNT?=1
+T?=""
 
 .PHONY: install_dependencies
 install_dependencies:
@@ -11,7 +13,7 @@ unit_tests:
 
 .PHONY: e2e_tests
 e2e_tests:
-	go test -failfast -v ./e2e
+	go test -failfast -count=$(COUNT) -run=$(T) -v ./e2e
 
 .PHONY: codegen
 codegen:

--- a/e2e/escalation_cond.go
+++ b/e2e/escalation_cond.go
@@ -1,6 +1,9 @@
 package e2e
 
 import (
+	"testing"
+	"time"
+
 	"k8s.io/apimachinery/pkg/runtime"
 
 	kudov1alpha1 "github.com/jlevesy/kudo/pkg/apis/k8s.kudo.dev/v1alpha1"
@@ -38,4 +41,34 @@ func escalationStatusMatchesSpec(want escalationWaitCondSpec, got kudov1alpha1.E
 	}
 
 	return true
+}
+
+func assertGrantedK8sResourcesCreated(t *testing.T, esc kudov1alpha1.Escalation, resource string) {
+	for _, ref := range esc.Status.GrantRefs {
+		assertObjectCreated(
+			t,
+			admin.k8s.RbacV1().RESTClient(),
+			resourceNameNamespace{
+				resource:  resource,
+				name:      ref.Name,
+				namespace: ref.Namespace,
+			},
+			30*time.Second,
+		)
+	}
+}
+
+func assertGrantedK8sResourcesDeleted(t *testing.T, esc kudov1alpha1.Escalation, resource string) {
+	for _, ref := range esc.Status.GrantRefs {
+		assertObjectDeleted(
+			t,
+			admin.k8s.RbacV1().RESTClient(),
+			resourceNameNamespace{
+				resource:  resource,
+				name:      ref.Name,
+				namespace: ref.Namespace,
+			},
+			30*time.Second,
+		)
+	}
 }

--- a/e2e/fixtures.go
+++ b/e2e/fixtures.go
@@ -55,6 +55,12 @@ func withGrants(grants ...kudov1alpha1.EscalationGrant) escalationPolicyOption {
 	}
 }
 
+func withExpiration(duration time.Duration) escalationPolicyOption {
+	return func(p *kudov1alpha1.EscalationPolicy) {
+		p.Spec.Target.Duration = metav1.Duration{Duration: duration}
+	}
+}
+
 func generateEscalationPolicy(t *testing.T, opts ...escalationPolicyOption) kudov1alpha1.EscalationPolicy {
 	t.Helper()
 

--- a/granter/granter.go
+++ b/granter/granter.go
@@ -2,8 +2,13 @@ package granter
 
 import (
 	"context"
+	"errors"
 
 	kudov1alpha1 "github.com/jlevesy/kudo/pkg/apis/k8s.kudo.dev/v1alpha1"
+)
+
+var (
+	ErrTampered = errors.New("kudo managed resource has been tampered with")
 )
 
 // Granter allows to create or reclaim a grant.

--- a/helm/crds/escalations.yaml
+++ b/helm/crds/escalations.yaml
@@ -52,6 +52,10 @@ spec:
                         type: string
                       namespace:
                         type: string
+                      uid:
+                        type: string
+                      resourceVersion:
+                        type: string
                       status:
                         type: string
 

--- a/pkg/apis/k8s.kudo.dev/v1alpha1/types.go
+++ b/pkg/apis/k8s.kudo.dev/v1alpha1/types.go
@@ -1,9 +1,11 @@
 package v1alpha1
 
 import (
-	"github.com/jlevesy/kudo/pkg/generics"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/jlevesy/kudo/pkg/generics"
 )
 
 const Version = "v1alpha1"
@@ -107,10 +109,12 @@ const (
 )
 
 type EscalationGrantRef struct {
-	Kind      string      `json:"kind"`
-	Name      string      `json:"name"`
-	Namespace string      `json:"namespace"`
-	Status    GrantStatus `json:"status"`
+	Kind            string      `json:"kind"`
+	Name            string      `json:"name"`
+	Namespace       string      `json:"namespace"`
+	UID             types.UID   `json:"uid"`
+	ResourceVersion string      `json:"resourceVersion"`
+	Status          GrantStatus `json:"status"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
### What does this PR do?

This PR:

- Updates the `GrantReference` to store the target role binding UID and ResourceVersion
- Make the `k8sRoleBindingGranter`
  - Rely on knowns grant to looking for existing bindings
  - Check if the binding hasn't been tampeered with by checking its UID and ResourceVersion
- Write an e2e test to handle this case