### PR TITLE
Deny an escalation if the policy has changed

### DIFF
--- a/e2e/controller_test.go
+++ b/e2e/controller_test.go
@@ -1,0 +1,124 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jlevesy/kudo/granter"
+	kudov1alpha1 "github.com/jlevesy/kudo/pkg/apis/k8s.kudo.dev/v1alpha1"
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// This test makes sure that kudo denies an active escalation whose policy has changed after the escalation
+// has been created.
+func TestEscalation_Controller_DenyEscalationIfPolicyChanges(t *testing.T) {
+	t.Parallel()
+
+	var (
+		ctx       = context.Background()
+		namespace = generateNamespace(t, 0)
+		role      = generateRole(t, 0, namespace.Name, rbacv1.PolicyRule{
+			Verbs:     []string{"list"},
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+		})
+		policy = generateEscalationPolicy(
+			t,
+			withExpiration(60*time.Minute), // Should not expire.
+			withGrants(
+				kudov1alpha1.EscalationGrant{
+					Kind:      granter.K8sRoleBindingGranterKind,
+					Namespace: namespace.Name,
+					RoleRef: rbacv1.RoleRef{
+						Kind: "Role",
+						Name: role.Name,
+					},
+				},
+			),
+		)
+
+		escalation = generateEscalation(t, policy.Name)
+
+		err error
+	)
+
+	_, err = admin.k8s.CoreV1().Namespaces().Create(ctx, &namespace, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = admin.k8s.RbacV1().Roles(namespace.Name).Create(
+		ctx,
+		&role,
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	gotPolicy, err := admin.kudo.K8sV1alpha1().EscalationPolicies().Create(ctx, &policy, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = userA.kudo.K8sV1alpha1().Escalations().Create(ctx, &escalation, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// admin waits for escalation to reach state ACCEPTED, and grants are created
+	rawEsc := assertObjectUpdated(
+		t,
+		admin.kudo.K8sV1alpha1().RESTClient(),
+		resourceNameNamespace{
+			resource: "escalations",
+			name:     escalation.Name,
+			global:   true,
+		},
+		condEscalationStatusMatchesSpec(
+			escalationWaitCondSpec{
+				state: kudov1alpha1.StateAccepted,
+				grantStatuses: []kudov1alpha1.GrantStatus{
+					kudov1alpha1.GrantStatusCreated,
+				},
+			},
+		),
+		30*time.Second,
+	)
+
+	gotEsc := as[*kudov1alpha1.Escalation](t, rawEsc)
+
+	// Now admin mutates the policy.
+	gotPolicy.Spec.Target.Grants = append(
+		policy.Spec.Target.Grants,
+		kudov1alpha1.EscalationGrant{
+			Kind:      granter.K8sRoleBindingGranterKind,
+			Namespace: "foo",
+			RoleRef: rbacv1.RoleRef{
+				Kind: "ClusterRole",
+				Name: "some-other-role",
+			},
+		},
+	)
+
+	_, err = admin.kudo.K8sV1alpha1().EscalationPolicies().Update(ctx, gotPolicy, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// Kudo should respond and deny the escalation.
+	assertObjectUpdated(
+		t,
+		admin.kudo.K8sV1alpha1().RESTClient(),
+		resourceNameNamespace{
+			resource: "escalations",
+			name:     escalation.Name,
+			global:   true,
+		},
+		condEscalationStatusMatchesSpec(
+			escalationWaitCondSpec{
+				state: kudov1alpha1.StateDenied,
+				grantStatuses: []kudov1alpha1.GrantStatus{
+					kudov1alpha1.GrantStatusReclaimed,
+				},
+			},
+		),
+		30*time.Second,
+	)
+
+	// Bindings are reclaimed.
+	assertGrantedK8sResourcesDeleted(t, *gotEsc, "rolebindings")
+}

--- a/escalation/controller_test.go
+++ b/escalation/controller_test.go
@@ -257,7 +257,7 @@ func TestEscalationController_OnUpdate(t *testing.T) {
 			},
 			wantEscalationStatus: kudov1alpha1.EscalationStatus{
 				State:        kudov1alpha1.StateExpired,
-				StateDetails: escalation.ExpiredWillReclaimStateDetails,
+				StateDetails: escalation.ExpiredStateDetails,
 				GrantRefs:    []kudov1alpha1.EscalationGrantRef{{}},
 			},
 		},
@@ -331,7 +331,7 @@ func TestEscalationController_OnUpdate(t *testing.T) {
 			},
 			wantEscalationStatus: kudov1alpha1.EscalationStatus{
 				State:        kudov1alpha1.StateExpired,
-				StateDetails: escalation.ExpiredWillReclaimStateDetails,
+				StateDetails: escalation.ExpiredStateDetails,
 				GrantRefs:    []kudov1alpha1.EscalationGrantRef{{}},
 			},
 		},
@@ -526,7 +526,8 @@ func TestEscalationController_OnUpdate(t *testing.T) {
 					PolicyName: testPolicy.Name,
 				},
 				Status: kudov1alpha1.EscalationStatus{
-					State: kudov1alpha1.StateExpired,
+					State:        kudov1alpha1.StateExpired,
+					StateDetails: "expiration has expired",
 					GrantRefs: []kudov1alpha1.EscalationGrantRef{
 						{
 							Kind:   testGrantKind,
@@ -543,7 +544,7 @@ func TestEscalationController_OnUpdate(t *testing.T) {
 			},
 			wantEscalationStatus: kudov1alpha1.EscalationStatus{
 				State:        kudov1alpha1.StateExpired,
-				StateDetails: escalation.ExpiredReclaimedStateDetails,
+				StateDetails: "expiration has expired",
 				GrantRefs: []kudov1alpha1.EscalationGrantRef{
 					{
 						Kind:   testGrantKind,
@@ -619,7 +620,8 @@ func TestEscalationController_OnUpdate(t *testing.T) {
 					PolicyName: testPolicy.Name,
 				},
 				Status: kudov1alpha1.EscalationStatus{
-					State: kudov1alpha1.StateDenied,
+					State:        kudov1alpha1.StateDenied,
+					StateDetails: "denied for some reason",
 					GrantRefs: []kudov1alpha1.EscalationGrantRef{
 						{
 							Kind:   testGrantKind,
@@ -636,7 +638,7 @@ func TestEscalationController_OnUpdate(t *testing.T) {
 			},
 			wantEscalationStatus: kudov1alpha1.EscalationStatus{
 				State:        kudov1alpha1.StateDenied,
-				StateDetails: escalation.DeniedReclaimedStateDetails,
+				StateDetails: "denied for some reason",
 				GrantRefs: []kudov1alpha1.EscalationGrantRef{
 					{
 						Kind:   testGrantKind,

--- a/helm/crds/escalations.yaml
+++ b/helm/crds/escalations.yaml
@@ -41,6 +41,10 @@ spec:
                   type: string
                 stateDetails:
                   type: string
+                policyUid:
+                  type: string
+                policyVersion:
+                  type: string
                 grantRefs:
                   type: array
                   items:

--- a/pkg/apis/k8s.kudo.dev/v1alpha1/types.go
+++ b/pkg/apis/k8s.kudo.dev/v1alpha1/types.go
@@ -95,9 +95,11 @@ const (
 )
 
 type EscalationStatus struct {
-	State        EscalationState      `json:"state"`
-	StateDetails string               `json:"stateDetails"`
-	GrantRefs    []EscalationGrantRef `json:"grantRefs"`
+	State         EscalationState      `json:"state"`
+	StateDetails  string               `json:"stateDetails"`
+	GrantRefs     []EscalationGrantRef `json:"grantRefs"`
+	PolicyUID     types.UID            `json:"policyUid"`
+	PolicyVersion string               `json:"policyVersion"`
 }
 
 type GrantStatus string

--- a/pkg/apis/k8s.kudo.dev/v1alpha1/types.go
+++ b/pkg/apis/k8s.kudo.dev/v1alpha1/types.go
@@ -102,6 +102,37 @@ type EscalationStatus struct {
 	PolicyVersion string               `json:"policyVersion"`
 }
 
+type TransitionMutation func(st *EscalationStatus)
+
+func WithNewGrantRefs(grantRefs []EscalationGrantRef) TransitionMutation {
+	return func(st *EscalationStatus) {
+		st.GrantRefs = grantRefs
+	}
+}
+
+func WithPolicyInfo(uid types.UID, version string) TransitionMutation {
+	return func(st *EscalationStatus) {
+		st.PolicyUID = uid
+		st.PolicyVersion = version
+	}
+}
+
+func (e *EscalationStatus) TransitionTo(state EscalationState, details string, mutations ...TransitionMutation) EscalationStatus {
+	newStatus := EscalationStatus{
+		State:         state,
+		StateDetails:  details,
+		GrantRefs:     e.GrantRefs,
+		PolicyUID:     e.PolicyUID,
+		PolicyVersion: e.PolicyVersion,
+	}
+
+	for _, mut := range mutations {
+		mut(&newStatus)
+	}
+
+	return newStatus
+}
+
 type GrantStatus string
 
 const (

--- a/pkg/apis/k8s.kudo.dev/v1alpha1/types.go
+++ b/pkg/apis/k8s.kudo.dev/v1alpha1/types.go
@@ -104,6 +104,12 @@ type EscalationStatus struct {
 
 type TransitionMutation func(st *EscalationStatus)
 
+func WithDetails(details string) TransitionMutation {
+	return func(st *EscalationStatus) {
+		st.StateDetails = details
+	}
+}
+
 func WithNewGrantRefs(grantRefs []EscalationGrantRef) TransitionMutation {
 	return func(st *EscalationStatus) {
 		st.GrantRefs = grantRefs
@@ -117,10 +123,10 @@ func WithPolicyInfo(uid types.UID, version string) TransitionMutation {
 	}
 }
 
-func (e *EscalationStatus) TransitionTo(state EscalationState, details string, mutations ...TransitionMutation) EscalationStatus {
+func (e *EscalationStatus) TransitionTo(state EscalationState, mutations ...TransitionMutation) EscalationStatus {
 	newStatus := EscalationStatus{
 		State:         state,
-		StateDetails:  details,
+		StateDetails:  e.StateDetails,
 		GrantRefs:     e.GrantRefs,
 		PolicyUID:     e.PolicyUID,
 		PolicyVersion: e.PolicyVersion,

--- a/pkg/generated/clientset/versioned/fake/register.go
+++ b/pkg/generated/clientset/versioned/fake/register.go
@@ -21,14 +21,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/generated/clientset/versioned/scheme/register.go
+++ b/pkg/generated/clientset/versioned/scheme/register.go
@@ -21,14 +21,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.


### PR DESCRIPTION
### What Does This PR do?

This PR makes kudo deny an escalation if the policy has changed after that the escalation is created. It detects the changes by  storing when the escalation is created the policy resourceVersion and the policy UID in the escalation status.
From there at each resync, it compares those values with the current state of the policy. If they have changed then the escalation is denied.

A new `TransitionTo` method has been added to `Escalation` to make sure that the escalation status is always fully copied when transitioning.

Fixes #9 

### How to Test This PR?

```bash
make run_dev

make run_escalation_dev

#within 30s, change the escalation policy and apply it, you should see your escalation denied.
```

### Good PR Checklist

- [x] Addresses one issue
- [x] Adds/Updates unit tests
- [x] Adds/Updates e2e tests
- [ ] ~Adds/Updates the documentation~
- [x] Opened against the right branch
- [x] Correctly Labeled