### PR TITLE
Snappy reclaims and do not rely on informer resync.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install_dependencies:
 
 .PHONY: unit_tests
 unit_tests:
-	go test -failfast -cover $(shell go list ./... | grep -v e2e)
+	go test -failfast -count=$(COUNT) -cover $(shell go list ./... | grep -v e2e)
 
 .PHONY: e2e_tests
 e2e_tests:

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -32,7 +32,7 @@ var (
 	webhookConfig webhooksupport.ServerConfig
 )
 
-const defaultInformerResyncInterval = 30 * time.Second
+const defaultInformerResyncInterval = time.Hour
 
 func main() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -25,9 +25,11 @@ import (
 )
 
 var (
-	masterURL   string
-	kubeconfig  string
-	threadiness int
+	masterURL      string
+	kubeconfig     string
+	threadiness    int
+	resyncInterval time.Duration
+	retryInterval  time.Duration
 
 	webhookConfig webhooksupport.ServerConfig
 )
@@ -41,6 +43,8 @@ func main() {
 	flag.StringVar(&webhookConfig.KeyPath, "webhook_key", "", "Path to webhook TLS key")
 	flag.StringVar(&webhookConfig.Addr, "webhook_addr", ":8080", "Webhook listening address")
 	flag.IntVar(&threadiness, "threadiness", 10, "Amount of events processed in paralled")
+	flag.DurationVar(&resyncInterval, "resync_interval", 30*time.Second, "Maximum period to resync an active escalation")
+	flag.DurationVar(&retryInterval, "retry_interval", 10*time.Second, "Maximum period retry an escalation not fully granted/reclaimed")
 	klog.InitFlags(nil)
 
 	flag.Parse()
@@ -81,6 +85,8 @@ func main() {
 				policiesLister,
 				escalationsClient,
 				granterFactory,
+				escalation.WithResyncInterval(resyncInterval),
+				escalation.WithRetryInterval(retryInterval),
 			),
 			kudov1alpha1.KindEscalation,
 			threadiness,

--- a/e2e/runtime.go
+++ b/e2e/runtime.go
@@ -242,6 +242,8 @@ func installKudo(ctx context.Context, kubeConfigPath string) error {
 				"--create-namespace",
 				"--namespace=" + kudoInstallNamespace,
 				"--set=image.devRef=" + imageRef,
+				"--set=controller.resyncInterval=5s",
+				"--set=controller.retryInterval=1s",
 				"--wait",
 				"--timeout=1m",
 				"kudo-e2e",

--- a/escalation/controller.go
+++ b/escalation/controller.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jlevesy/kudo/grant"
 	kudov1alpha1 "github.com/jlevesy/kudo/pkg/apis/k8s.kudo.dev/v1alpha1"
+	"github.com/jlevesy/kudo/pkg/controllersupport"
 )
 
 const (
@@ -30,34 +31,70 @@ type EscalationStatusUpdater interface {
 	UpdateStatus(ctx context.Context, escalation *kudov1alpha1.Escalation, opts metav1.UpdateOptions) (*kudov1alpha1.Escalation, error)
 }
 
+type EventInsight = controllersupport.EventInsight[kudov1alpha1.Escalation]
+
 type Controller struct {
 	policiesGetter          EscalationPoliciesGetter
 	escalationStatusUpdater EscalationStatusUpdater
 	granterFactory          grant.Factory
+	nowFunc                 func() time.Time
+	resyncInterval          time.Duration
+	retryInterval           time.Duration
+}
+
+type ControllerOpt func(c *Controller)
+
+func WithNowFunc(now func() time.Time) ControllerOpt {
+	return func(c *Controller) {
+		c.nowFunc = now
+	}
+}
+
+func WithResyncInterval(d time.Duration) ControllerOpt {
+	return func(c *Controller) {
+		c.resyncInterval = d
+	}
+}
+
+func WithRetryInterval(d time.Duration) ControllerOpt {
+	return func(c *Controller) {
+		c.retryInterval = d
+	}
 }
 
 func NewController(
 	policiesGetter EscalationPoliciesGetter,
 	escalationStatusUpdater EscalationStatusUpdater,
 	granterFactory grant.Factory,
+	opts ...ControllerOpt,
 ) *Controller {
-	return &Controller{
+	c := Controller{
 		policiesGetter:          policiesGetter,
 		escalationStatusUpdater: escalationStatusUpdater,
 		granterFactory:          granterFactory,
+		nowFunc:                 time.Now,
+		resyncInterval:          30 * time.Second,
+		retryInterval:           5 * time.Second,
 	}
+
+	for _, opt := range opts {
+		opt(&c)
+	}
+
+	return &c
 }
 
-func (h *Controller) OnAdd(ctx context.Context, escalation *kudov1alpha1.Escalation) error {
+func (h *Controller) OnAdd(ctx context.Context, escalation *kudov1alpha1.Escalation) (EventInsight, error) {
 	policy, newStatus, updated, err := h.readPolicyAndCheckExpiration(ctx, escalation)
 	if err != nil {
-		return err
+		return EventInsight{}, err
 	}
 	if updated {
-		return h.updateStatus(ctx, escalation, newStatus)
+		_, err = h.updateStatus(ctx, escalation, newStatus)
+		return EventInsight{}, err
 	}
 
-	return h.updateStatus(
+	_, err = h.updateStatus(
 		ctx,
 		escalation,
 		escalation.Status.TransitionTo(
@@ -66,32 +103,45 @@ func (h *Controller) OnAdd(ctx context.Context, escalation *kudov1alpha1.Escalat
 			kudov1alpha1.WithPolicyInfo(policy.UID, policy.ResourceVersion),
 		),
 	)
+
+	return EventInsight{}, err
 }
 
-func (h *Controller) OnUpdate(ctx context.Context, oldEsc, newEsc *kudov1alpha1.Escalation) error {
-	status, err := h.reconcileState(ctx, oldEsc, newEsc)
-
+func (c *Controller) OnUpdate(ctx context.Context, _, esc *kudov1alpha1.Escalation) (EventInsight, error) {
+	status, err := c.reconcileState(ctx, esc)
 	if err != nil {
-		return err
+		return EventInsight{}, err
 	}
 
-	return h.updateStatus(ctx, newEsc, status)
+	updatedEsc, err := c.updateStatus(ctx, esc, status)
+	if err != nil {
+		return EventInsight{}, err
+	}
+
+	// If the resource has been updated, we'll get an update event, no need to reschedule anything.
+	if esc.ResourceVersion != updatedEsc.ResourceVersion {
+		return EventInsight{}, nil
+	}
+
+	// If no update, then let's pick an appropriate next schedule time.
+	nextInsight := c.nextEventInsight(updatedEsc)
+
+	if nextInsight.ResyncAfter > 0 {
+		klog.InfoS("Next processing scheduled", "escalation", updatedEsc.Name, "in", nextInsight.ResyncAfter)
+	}
+
+	return nextInsight, nil
 }
 
-func (h *Controller) OnDelete(ctx context.Context, esc *kudov1alpha1.Escalation) error {
+func (h *Controller) OnDelete(ctx context.Context, esc *kudov1alpha1.Escalation) (EventInsight, error) {
 	// TODO(jly) try to reclaim.
-	return nil
+	return EventInsight{}, nil
 }
 
-func hasPolicyChanged(esc *kudov1alpha1.Escalation, policy *kudov1alpha1.EscalationPolicy) bool {
-	return policy.UID != esc.Status.PolicyUID ||
-		policy.ResourceVersion != esc.Status.PolicyVersion
-}
-
-func (h *Controller) reconcileState(ctx context.Context, _, newEsc *kudov1alpha1.Escalation) (kudov1alpha1.EscalationStatus, error) {
+func (c *Controller) reconcileState(ctx context.Context, newEsc *kudov1alpha1.Escalation) (kudov1alpha1.EscalationStatus, error) {
 	switch newEsc.Status.State {
 	case kudov1alpha1.StatePending:
-		policy, newStatus, updated, err := h.readPolicyAndCheckExpiration(ctx, newEsc)
+		policy, newStatus, updated, err := c.readPolicyAndCheckExpiration(ctx, newEsc)
 		if err != nil {
 			return statusZero, err
 		}
@@ -112,11 +162,12 @@ func (h *Controller) reconcileState(ctx context.Context, _, newEsc *kudov1alpha1
 		// if ok, transition to accepted.
 		return newEsc.Status.TransitionTo(
 			kudov1alpha1.StateAccepted,
+			kudov1alpha1.WithExpiresAt(c.nowFunc().Add(policy.Spec.Target.Duration.Duration)),
 			kudov1alpha1.WithDetails(AcceptedInProgressStateDetails),
 		), nil
 
 	case kudov1alpha1.StateAccepted:
-		policy, newStatus, updated, err := h.readPolicyAndCheckExpiration(ctx, newEsc)
+		policy, newStatus, updated, err := c.readPolicyAndCheckExpiration(ctx, newEsc)
 		if err != nil {
 			return statusZero, err
 		}
@@ -131,10 +182,10 @@ func (h *Controller) reconcileState(ctx context.Context, _, newEsc *kudov1alpha1
 			), nil
 		}
 
-		return h.createGrants(ctx, newEsc, policy)
+		return c.createGrants(ctx, newEsc, policy)
 
 	case kudov1alpha1.StateExpired:
-		grantRefs, err := h.reclaimGrants(ctx, newEsc)
+		grantRefs, err := c.reclaimGrants(ctx, newEsc)
 		if err != nil {
 			return newEsc.Status.TransitionTo(
 				kudov1alpha1.StateExpired,
@@ -154,7 +205,7 @@ func (h *Controller) reconcileState(ctx context.Context, _, newEsc *kudov1alpha1
 		), nil
 
 	case kudov1alpha1.StateDenied:
-		grantRefs, err := h.reclaimGrants(ctx, newEsc)
+		grantRefs, err := c.reclaimGrants(ctx, newEsc)
 		if err != nil {
 			return newEsc.Status.TransitionTo(
 				kudov1alpha1.StateDenied,
@@ -269,11 +320,9 @@ func (h *Controller) reclaimGrants(ctx context.Context, esc *kudov1alpha1.Escala
 	return grantRefs, nil
 }
 
-func (h *Controller) readPolicyAndCheckExpiration(ctx context.Context, esc *kudov1alpha1.Escalation) (*kudov1alpha1.EscalationPolicy, kudov1alpha1.EscalationStatus, bool, error) {
-	now := time.Now()
-
+func (c *Controller) readPolicyAndCheckExpiration(ctx context.Context, esc *kudov1alpha1.Escalation) (*kudov1alpha1.EscalationPolicy, kudov1alpha1.EscalationStatus, bool, error) {
 	// Does the referenced policy exists?
-	policy, err := h.policiesGetter.Get(esc.Spec.PolicyName)
+	policy, err := c.policiesGetter.Get(esc.Spec.PolicyName)
 	switch {
 	case errors.IsNotFound(err):
 		return nil,
@@ -289,7 +338,7 @@ func (h *Controller) readPolicyAndCheckExpiration(ctx context.Context, esc *kudo
 	}
 
 	// Is the escalation already expired? If so, transition its state and abort.
-	if now.After(esc.CreationTimestamp.Add(policy.Spec.Target.Duration.Duration)) {
+	if c.nowFunc().After(esc.CreationTimestamp.Add(policy.Spec.Target.Duration.Duration)) {
 		return nil,
 			esc.Status.TransitionTo(
 				kudov1alpha1.StateExpired,
@@ -302,7 +351,7 @@ func (h *Controller) readPolicyAndCheckExpiration(ctx context.Context, esc *kudo
 	return policy, statusZero, false, nil
 }
 
-func (h *Controller) updateStatus(ctx context.Context, escalation *kudov1alpha1.Escalation, status kudov1alpha1.EscalationStatus) error {
+func (h *Controller) updateStatus(ctx context.Context, escalation *kudov1alpha1.Escalation, status kudov1alpha1.EscalationStatus) (*kudov1alpha1.Escalation, error) {
 	clonedEscalation := escalation.DeepCopy()
 	clonedEscalation.Status = status
 
@@ -318,7 +367,49 @@ func (h *Controller) updateStatus(ctx context.Context, escalation *kudov1alpha1.
 		)
 	}
 
-	_, err := h.escalationStatusUpdater.UpdateStatus(ctx, clonedEscalation, metav1.UpdateOptions{})
+	return h.escalationStatusUpdater.UpdateStatus(ctx, clonedEscalation, metav1.UpdateOptions{})
+}
 
-	return err
+func (c *Controller) nextEventInsight(esc *kudov1alpha1.Escalation) EventInsight {
+	switch esc.Status.State {
+	case kudov1alpha1.StateAccepted:
+		if !esc.Status.AllGrantsInStatus(kudov1alpha1.GrantStatusCreated) {
+			return EventInsight{
+				ResyncAfter: c.retryInterval,
+				Object:      esc,
+			}
+		}
+
+		var (
+			resyncDelay       = c.resyncInterval
+			delayToExpiration = esc.Status.ExpiresAt.Sub(c.nowFunc())
+		)
+
+		if delayToExpiration < resyncDelay {
+			resyncDelay = delayToExpiration
+		}
+
+		return EventInsight{
+			ResyncAfter: resyncDelay,
+			Object:      esc,
+		}
+	case kudov1alpha1.StateDenied, kudov1alpha1.StateExpired:
+		if !esc.Status.AllGrantsInStatus(kudov1alpha1.GrantStatusReclaimed) {
+			return EventInsight{
+				ResyncAfter: c.retryInterval,
+				Object:      esc,
+			}
+		}
+
+		klog.InfoS("Not resyncing because denied / expired and all reclaimed", "escalation", esc.Name)
+		return EventInsight{}
+	default:
+		klog.InfoS("Not resyncing because in unreschedulable state", "escalation", esc.Name, "state", esc.Status.State)
+		return EventInsight{}
+	}
+}
+
+func hasPolicyChanged(esc *kudov1alpha1.Escalation, policy *kudov1alpha1.EscalationPolicy) bool {
+	return policy.UID != esc.Status.PolicyUID ||
+		policy.ResourceVersion != esc.Status.PolicyVersion
 }

--- a/escalation/controller_test.go
+++ b/escalation/controller_test.go
@@ -90,10 +90,32 @@ func TestEscalationController_OnCreate(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-escalation",
 				},
+				Spec: kudov1alpha1.EscalationSpec{
+					PolicyName: testPolicy.Name,
+					Requestor:  "john-claude",
+					Reason:     "blah blah",
+				},
 			},
 			wantEscalationStatus: kudov1alpha1.EscalationStatus{
 				State:        kudov1alpha1.StateDenied,
 				StateDetails: escalation.DeniedPolicyNotFoundStateDetails,
+			},
+		},
+		{
+			desc: "denies escalation if escalation spec isn't complete",
+			createdEscalation: kudov1alpha1.Escalation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-escalation",
+				},
+				Spec: kudov1alpha1.EscalationSpec{
+					PolicyName: testPolicy.Name,
+					Requestor:  "john-claude",
+					Reason:     "         ",
+				},
+			},
+			wantEscalationStatus: kudov1alpha1.EscalationStatus{
+				State:        kudov1alpha1.StateDenied,
+				StateDetails: escalation.DeniedBadEscalationSpec,
 			},
 		},
 		{
@@ -108,6 +130,8 @@ func TestEscalationController_OnCreate(t *testing.T) {
 				},
 				Spec: kudov1alpha1.EscalationSpec{
 					PolicyName: testPolicy.Name,
+					Requestor:  "john-claude",
+					Reason:     "blah blah",
 				},
 			},
 			wantEscalationStatus: kudov1alpha1.EscalationStatus{

--- a/examples/resources/escalation-policy.yaml
+++ b/examples/resources/escalation-policy.yaml
@@ -13,7 +13,7 @@ spec:
         - kind: Group
           name: squad-b@voiapp.io
   target: # (required) what the escalation grants
-    duration: 30s
+    duration: 10s
     grants:
     - kind: KubernetesRoleBinding
       defaultNamespace: some-app

--- a/examples/resources/escalation-policy.yaml
+++ b/examples/resources/escalation-policy.yaml
@@ -13,7 +13,7 @@ spec:
         - kind: Group
           name: squad-b@voiapp.io
   target: # (required) what the escalation grants
-    duration: 10s
+    duration: 70s
     grants:
     - kind: KubernetesRoleBinding
       defaultNamespace: some-app

--- a/helm/crds/escalations.yaml
+++ b/helm/crds/escalations.yaml
@@ -47,6 +47,8 @@ spec:
                   type: string
                 policyVersion:
                   type: string
+                expiresAt:
+                  type: string
                 grantRefs:
                   type: array
                   items:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
             - "/var/run/certs/tls.key"
             - "-webhook_addr"
             - ":443"
+            - "-resync_interval"
+            - {{ .Values.controller.resyncInterval | quote }}
+            - "-retry_interval"
+            - {{ .Values.controller.retryInterval | quote }}
           ports:
             - name: https
               containerPort: 443

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,5 +1,9 @@
 replicaCount: 1
 
+controller:
+  resyncInterval: 30s
+  retryInterval: 10s
+
 image:
   repository: ghcr.io/jlevesy/kudo/controller
   pullPolicy: Always

--- a/pkg/apis/k8s.kudo.dev/v1alpha1/types.go
+++ b/pkg/apis/k8s.kudo.dev/v1alpha1/types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"strings"
 	"time"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -89,6 +90,14 @@ type EscalationSpec struct {
 	Reason     string `json:"reason"`
 	Namespace  string `json:"namespace"`
 }
+
+func (e *EscalationSpec) IsValid() bool {
+	return notBlank(e.PolicyName) &&
+		notBlank(e.Requestor) &&
+		notBlank(e.Reason)
+}
+
+func notBlank(v string) bool { return strings.TrimSpace(v) != "" }
 
 type EscalationState string
 

--- a/pkg/apis/k8s.kudo.dev/v1alpha1/types.go
+++ b/pkg/apis/k8s.kudo.dev/v1alpha1/types.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"time"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -101,9 +103,24 @@ const (
 type EscalationStatus struct {
 	State         EscalationState      `json:"state"`
 	StateDetails  string               `json:"stateDetails"`
-	GrantRefs     []EscalationGrantRef `json:"grantRefs"`
 	PolicyUID     types.UID            `json:"policyUid"`
 	PolicyVersion string               `json:"policyVersion"`
+	ExpiresAt     metav1.Time          `json:"expiresAt"`
+	GrantRefs     []EscalationGrantRef `json:"grantRefs"`
+}
+
+func (e *EscalationStatus) AllGrantsInStatus(wantStatus GrantStatus) bool {
+	if len(e.GrantRefs) == 0 {
+		return false
+	}
+
+	for _, ref := range e.GrantRefs {
+		if ref.Status != wantStatus {
+			return false
+		}
+	}
+
+	return true
 }
 
 type TransitionMutation func(st *EscalationStatus)
@@ -127,6 +144,12 @@ func WithPolicyInfo(uid types.UID, version string) TransitionMutation {
 	}
 }
 
+func WithExpiresAt(t time.Time) TransitionMutation {
+	return func(st *EscalationStatus) {
+		st.ExpiresAt = metav1.Time{Time: t}
+	}
+}
+
 func (e *EscalationStatus) TransitionTo(state EscalationState, mutations ...TransitionMutation) EscalationStatus {
 	newStatus := EscalationStatus{
 		State:         state,
@@ -134,6 +157,7 @@ func (e *EscalationStatus) TransitionTo(state EscalationState, mutations ...Tran
 		GrantRefs:     e.GrantRefs,
 		PolicyUID:     e.PolicyUID,
 		PolicyVersion: e.PolicyVersion,
+		ExpiresAt:     e.ExpiresAt,
 	}
 
 	for _, mut := range mutations {

--- a/pkg/apis/k8s.kudo.dev/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/k8s.kudo.dev/v1alpha1/zz_generated.deepcopy.go
@@ -243,6 +243,7 @@ func (in *EscalationStatus) DeepCopyInto(out *EscalationStatus) {
 		*out = make([]EscalationGrantRef, len(*in))
 		copy(*out, *in)
 	}
+	in.ExpiresAt.DeepCopyInto(&out.ExpiresAt)
 	return
 }
 


### PR DESCRIPTION
### What Does This PR do?

This PR allows the controller to actually decides itself when to reprocess an event instead of relying on a global informer resync.
This allows us to schedule resync only for items that need resync, and also be clever about the resync delay. In our case if the resync interval is greater than time left for the escalation,  reschedule closer to when the escalation actually expires.

It's much more efficient, and makes the whole controller more reactive.

Few other perks:

- The controller now denies escalations that don't have mandatory values in their specs.
- Resync and Retry delays are now configurables, and e2e tests a run at a lower resync delay so that they stay fast.

Relates to: #28 

### How to Test This PR?

Create a common escalation and see it expire much closer that benfore, or

```
make e2e_tests
```

### Good PR Checklist

- [x] Addresses one issue
- [x] Adds/Updates unit tests
- [x] Adds/Updates e2e tests
- [ ] Adds/Updates the documentation
- [x] Opened against the right branch
- [x] Correctly Labeled