### PR TITLE
Introduce audit.Sink and record k8s events

### DIFF
--- a/audit/k8s_event_sink.go
+++ b/audit/k8s_event_sink.go
@@ -1,0 +1,45 @@
+package audit
+
+import (
+	"context"
+
+	kudov1alpha1 "github.com/jlevesy/kudo/pkg/apis/k8s.kudo.dev/v1alpha1"
+	"k8s.io/client-go/tools/record"
+)
+
+type k8sEventSink struct {
+	eventRecorder record.EventRecorder
+}
+
+func NewK8sEventSink(recorder record.EventRecorder) Sink {
+	return &k8sEventSink{eventRecorder: recorder}
+}
+
+func (s *k8sEventSink) RecordCreate(ctx context.Context, escalation *kudov1alpha1.Escalation) {
+	s.eventRecorder.Event(
+		escalation,
+		"Normal",
+		"Create",
+		"Escalation has been created",
+	)
+}
+
+func (s *k8sEventSink) RecordUpdate(ctx context.Context, _, escalation *kudov1alpha1.Escalation) {
+	s.eventRecorder.Eventf(
+		escalation,
+		"Normal",
+		"Update",
+		"New state %s, reason is: %s",
+		escalation.Status.State,
+		escalation.Status.StateDetails,
+	)
+}
+
+func (s *k8sEventSink) RecordDelete(ctx context.Context, escalation *kudov1alpha1.Escalation) {
+	s.eventRecorder.Event(
+		escalation,
+		"Warn",
+		"Delete",
+		"Escalation has been deleted",
+	)
+}

--- a/audit/sink.go
+++ b/audit/sink.go
@@ -1,0 +1,51 @@
+package audit
+
+import (
+	"context"
+
+	kudov1alpha1 "github.com/jlevesy/kudo/pkg/apis/k8s.kudo.dev/v1alpha1"
+	"k8s.io/klog/v2"
+)
+
+type Sink interface {
+	RecordCreate(ctx context.Context, esc *kudov1alpha1.Escalation)
+	RecordUpdate(ctx context.Context, oldEsc, newEsc *kudov1alpha1.Escalation)
+	RecordDelete(ctx context.Context, esc *kudov1alpha1.Escalation)
+}
+
+func MutliAsyncSink(sinks ...Sink) Sink { return multiAsyncSink(sinks) }
+
+type multiAsyncSink []Sink
+
+func (m multiAsyncSink) RecordCreate(ctx context.Context, esc *kudov1alpha1.Escalation) {
+	m.asyncDo(func(s Sink) {
+		s.RecordCreate(ctx, esc)
+	})
+}
+
+func (m multiAsyncSink) RecordUpdate(ctx context.Context, oldEsc, newEsc *kudov1alpha1.Escalation) {
+	m.asyncDo(func(s Sink) {
+		s.RecordUpdate(ctx, oldEsc, newEsc)
+	})
+}
+
+func (m multiAsyncSink) RecordDelete(ctx context.Context, esc *kudov1alpha1.Escalation) {
+	m.asyncDo(func(s Sink) {
+		s.RecordDelete(ctx, esc)
+	})
+}
+
+func (m multiAsyncSink) asyncDo(callback func(Sink)) {
+	for _, sink := range m {
+		sink := sink
+		go func() {
+			defer func() {
+				if err := recover(); err != nil {
+					klog.Error(err, "recovered panic from sink")
+				}
+			}()
+
+			callback(sink)
+		}()
+	}
+}

--- a/e2e/controller_test.go
+++ b/e2e/controller_test.go
@@ -5,13 +5,147 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	eventsv1 "k8s.io/api/events/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/jlevesy/kudo/grant"
 	kudov1alpha1 "github.com/jlevesy/kudo/pkg/apis/k8s.kudo.dev/v1alpha1"
 )
+
+// This test makes sure that audit events are properly recorded for an escalation.
+func TestEscalation_Controller_RecordsEscalationEvent(t *testing.T) {
+	t.Parallel()
+
+	var (
+		ctx       = context.Background()
+		namespace = generateNamespace(t, 0)
+		role      = generateRole(t, 0, namespace.Name, rbacv1.PolicyRule{
+			Verbs:     []string{"list"},
+			APIGroups: []string{""},
+			Resources: []string{"pods"},
+		})
+		policy = generateEscalationPolicy(
+			t,
+			withExpiration(5*time.Second),
+			withGrants(
+				kudov1alpha1.EscalationGrant{
+					Kind:              grant.K8sRoleBindingKind,
+					AllowedNamespaces: []string{namespace.Name},
+					RoleRef: rbacv1.RoleRef{
+						Kind: "Role",
+						Name: role.Name,
+					},
+				},
+			),
+		)
+
+		escalation = generateEscalation(t, policy.Name, withNamespace(namespace.Name))
+
+		err error
+	)
+
+	_, err = admin.k8s.CoreV1().Namespaces().Create(ctx, &namespace, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = admin.k8s.RbacV1().Roles(namespace.Name).Create(
+		ctx,
+		&role,
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	_, err = admin.kudo.K8sV1alpha1().EscalationPolicies().Create(ctx, &policy, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = userA.kudo.K8sV1alpha1().Escalations().Create(ctx, &escalation, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// admin waits for escalation to reach state ACCEPTED, and grants are created
+	rawEsc := assertObjectUpdated(
+		t,
+		admin.kudo.K8sV1alpha1().RESTClient(),
+		resourceNameNamespace{
+			resource: "escalations",
+			name:     escalation.Name,
+			global:   true,
+		},
+		condEscalationStatusMatchesSpec(
+			escalationWaitCondSpec{
+				state: kudov1alpha1.StateAccepted,
+				grantStatuses: []kudov1alpha1.GrantStatus{
+					kudov1alpha1.GrantStatusCreated,
+				},
+			},
+		),
+		30*time.Second,
+	)
+
+	gotEsc := as[*kudov1alpha1.Escalation](t, rawEsc)
+
+	// After a while, escalation expires.
+	assertObjectUpdated(
+		t,
+		admin.kudo.K8sV1alpha1().RESTClient(),
+		resourceNameNamespace{
+			resource: "escalations",
+			name:     escalation.Name,
+			global:   true,
+		},
+		condEscalationStatusMatchesSpec(
+			escalationWaitCondSpec{
+				state: kudov1alpha1.StateExpired,
+				grantStatuses: []kudov1alpha1.GrantStatus{
+					kudov1alpha1.GrantStatusReclaimed,
+				},
+			},
+		),
+		30*time.Second,
+	)
+
+	// Bindings are reclaimed.
+	assertGrantedK8sResourcesDeleted(t, *gotEsc, "rolebindings")
+
+	// Now list all event regarding this escalation and assert on them.
+	events, err := admin.k8s.EventsV1().Events("").List(
+		ctx,
+		metav1.ListOptions{
+			FieldSelector: "regarding.name=" + gotEsc.Name,
+		},
+	)
+	require.NoError(t, err)
+
+	wantEvents := []eventsv1.Event{
+		{
+			Reason: "Create",
+			Note:   "Escalation has been created",
+		},
+		{
+			Reason: "Update",
+			Note:   "New state PENDING, reason is: This escalation is being processed",
+		},
+		{
+			Reason: "Update",
+			Note:   "New state ACCEPTED, reason is: This escalation has been accepted, permissions are going to be granted in a few moments",
+		},
+		{
+			Reason: "Update",
+			Note:   "New state ACCEPTED, reason is: This escalation has been accepted, permissions are granted",
+		},
+		{
+			Reason: "Update",
+			Note:   "New state EXPIRED, reason is: This escalation has expired, all granted permissions are reclaimed",
+		},
+	}
+
+	for i, evt := range events.Items {
+		assert.Equal(t, wantEvents[i].Reason, evt.Reason)
+		assert.Equal(t, wantEvents[i].Note, evt.Note)
+	}
+
+}
 
 // This test makes sure that kudo denies an active escalation whose policy has changed after the escalation
 // has been created.

--- a/escalation/controller.go
+++ b/escalation/controller.go
@@ -85,9 +85,9 @@ func NewController(
 	return &c
 }
 
-func (h *Controller) OnAdd(ctx context.Context, escalation *kudov1alpha1.Escalation) (EventInsight, error) {
+func (c *Controller) OnAdd(ctx context.Context, escalation *kudov1alpha1.Escalation) (EventInsight, error) {
 	if !escalation.Spec.IsValid() {
-		_, err := h.updateStatus(
+		_, err := c.updateStatus(
 			ctx,
 			escalation,
 			escalation.Status.TransitionTo(
@@ -99,16 +99,16 @@ func (h *Controller) OnAdd(ctx context.Context, escalation *kudov1alpha1.Escalat
 		return EventInsight{}, err
 	}
 
-	policy, newStatus, updated, err := h.readPolicyAndCheckExpiration(ctx, escalation)
+	policy, newStatus, updated, err := c.readPolicyAndCheckExpiration(ctx, escalation)
 	if err != nil {
 		return EventInsight{}, err
 	}
 	if updated {
-		_, err = h.updateStatus(ctx, escalation, newStatus)
+		_, err = c.updateStatus(ctx, escalation, newStatus)
 		return EventInsight{}, err
 	}
 
-	_, err = h.updateStatus(
+	_, err = c.updateStatus(
 		ctx,
 		escalation,
 		escalation.Status.TransitionTo(
@@ -147,7 +147,7 @@ func (c *Controller) OnUpdate(ctx context.Context, _, esc *kudov1alpha1.Escalati
 	return nextInsight, nil
 }
 
-func (h *Controller) OnDelete(ctx context.Context, esc *kudov1alpha1.Escalation) (EventInsight, error) {
+func (c *Controller) OnDelete(ctx context.Context, esc *kudov1alpha1.Escalation) (EventInsight, error) {
 	// TODO(jly) try to reclaim.
 	return EventInsight{}, nil
 }
@@ -243,7 +243,7 @@ func (c *Controller) reconcileState(ctx context.Context, newEsc *kudov1alpha1.Es
 	}
 }
 
-func (h *Controller) createGrants(ctx context.Context, esc *kudov1alpha1.Escalation, policy *kudov1alpha1.EscalationPolicy) (kudov1alpha1.EscalationStatus, error) {
+func (c *Controller) createGrants(ctx context.Context, esc *kudov1alpha1.Escalation, policy *kudov1alpha1.EscalationPolicy) (kudov1alpha1.EscalationStatus, error) {
 	grantRefs := make([]kudov1alpha1.EscalationGrantRef, len(policy.Spec.Target.Grants))
 	group, ctx := errgroup.WithContext(ctx)
 
@@ -252,7 +252,7 @@ func (h *Controller) createGrants(ctx context.Context, esc *kudov1alpha1.Escalat
 		grant := grant
 
 		group.Go(func() error {
-			granter, err := h.granterFactory.Get(grant.Kind)
+			granter, err := c.granterFactory.Get(grant.Kind)
 			if err != nil {
 				return err
 			}
@@ -365,7 +365,7 @@ func (c *Controller) readPolicyAndCheckExpiration(ctx context.Context, esc *kudo
 	return policy, statusZero, false, nil
 }
 
-func (h *Controller) updateStatus(ctx context.Context, escalation *kudov1alpha1.Escalation, status kudov1alpha1.EscalationStatus) (*kudov1alpha1.Escalation, error) {
+func (c *Controller) updateStatus(ctx context.Context, escalation *kudov1alpha1.Escalation, status kudov1alpha1.EscalationStatus) (*kudov1alpha1.Escalation, error) {
 	clonedEscalation := escalation.DeepCopy()
 	clonedEscalation.Status = status
 
@@ -381,7 +381,7 @@ func (h *Controller) updateStatus(ctx context.Context, escalation *kudov1alpha1.
 		)
 	}
 
-	return h.escalationStatusUpdater.UpdateStatus(ctx, clonedEscalation, metav1.UpdateOptions{})
+	return c.escalationStatusUpdater.UpdateStatus(ctx, clonedEscalation, metav1.UpdateOptions{})
 }
 
 func (c *Controller) nextEventInsight(esc *kudov1alpha1.Escalation) EventInsight {

--- a/escalation/controller_test.go
+++ b/escalation/controller_test.go
@@ -12,7 +12,9 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 
+	"github.com/jlevesy/kudo/audit"
 	"github.com/jlevesy/kudo/escalation"
 	"github.com/jlevesy/kudo/grant"
 	kudov1alpha1 "github.com/jlevesy/kudo/pkg/apis/k8s.kudo.dev/v1alpha1"
@@ -115,7 +117,7 @@ func TestEscalationController_OnCreate(t *testing.T) {
 			},
 			wantEscalationStatus: kudov1alpha1.EscalationStatus{
 				State:        kudov1alpha1.StateDenied,
-				StateDetails: escalation.DeniedBadEscalationSpec,
+				StateDetails: escalation.DeniedBadEscalationSpecDetails,
 			},
 		},
 		{
@@ -915,6 +917,7 @@ func buildController(t *testing.T, granterFactory grant.Factory, kudoSeed []runt
 			k8s.kudoInformersFactory.K8s().V1alpha1().EscalationPolicies().Lister(),
 			k8s.kudoClientSet.K8sV1alpha1().Escalations(),
 			granterFactory,
+			audit.NewK8sEventSink(&record.FakeRecorder{}),
 			escalation.WithNowFunc(nowFunc),
 			escalation.WithResyncInterval(resyncDelay),
 			escalation.WithRetryInterval(retryDelay),

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,7 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -5,6 +5,13 @@ metadata:
   name: {{ include "helm.fullname" . }}-controller
 rules:
 - apiGroups:
+    - ""
+  resources:
+    - "events"
+  verbs:
+    - "create"
+    - "patch"
+- apiGroups:
     - "rbac.authorization.k8s.io"
   resources:
     - "roles"


### PR DESCRIPTION
### What Does This PR do?

- Introduces an `audit.Sink` interface which defines what a Sink should handle
- Implement a k8sEventsSink 
- Make the controller notify the `audit.Sink` on Add, Update and Delete.
- Also, make the controller drop existing permissions if an escalation gets deleted.  

Relates to: #30 

### How to Test This PR?

```bash
make run_dev

make run_escalation_dev

k describe your-escalation

# you should see some events.
```

### Good PR Checklist

- [ ] ~Addresses one issue~ eeeeh
- [x] Adds/Updates unit tests
- [x] Adds/Updates e2e tests
- [ ] ~Adds/Updates the documentation~
- [x] Opened against the right branch
- [x] Correctly Labeled
