### PR TITLE
Deny Update and Delete escalation

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -109,22 +109,12 @@ func main() {
 			kudov1alpha1.KindEscalation,
 			threadiness,
 		)
-		escalationReviewer = escalation.NewAdmissionReviewer(policiesLister, granterFactory)
 	)
 
 	escalationsInformer.AddEventHandler(escalationController)
-	serveMux.Handle(
-		"/v1alpha1/escalationpolicies",
-		webhooksupport.NewHandler(
-			escalationpolicy.NewAdmissionReviewer(),
-		),
-	)
-	serveMux.Handle(
-		"/v1alpha1/escalations",
-		webhooksupport.NewHandler(
-			escalationReviewer,
-		),
-	)
+
+	escalationpolicy.SetupWebhook(serveMux)
+	escalation.SetupWebhook(serveMux, kudoInformerFactory, granterFactory)
 	serveMux.HandleFunc("/healthz", func(rw http.ResponseWriter, r *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 		_, _ = rw.Write([]byte("ok"))

--- a/escalation/create_reviewer_test.go
+++ b/escalation/create_reviewer_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/jlevesy/kudo/pkg/generated/clientset/versioned/fake"
 	kudoinformers "github.com/jlevesy/kudo/pkg/generated/informers/externalversions"
 	"github.com/jlevesy/kudo/pkg/generics"
-	"github.com/jlevesy/kudo/pkg/webhooksupport"
 	"github.com/jlevesy/kudo/pkg/webhooksupport/webhooktesting"
 )
 
@@ -82,7 +81,7 @@ var (
 	}
 )
 
-func TestEscalationAdmissionReviewer_ReviewAdmission(t *testing.T) {
+func TestCreateEscalationAdmissionReviewer_ReviewAdmission(t *testing.T) {
 	testCases := []struct {
 		desc    string
 		request *admissionv1.AdmissionRequest
@@ -93,29 +92,8 @@ func TestEscalationAdmissionReviewer_ReviewAdmission(t *testing.T) {
 		wantResponse *admissionv1.AdmissionResponse
 	}{
 		{
-			desc: "raises an error if kind is unexpected",
-			request: &admissionv1.AdmissionRequest{
-				Kind: metav1.GroupVersionKind{
-					Group:   "something.bar",
-					Version: "v1",
-					Kind:    "Something",
-				},
-			},
-			wantError: webhooksupport.ErrUnexpectedKind,
-		},
-		{
-			desc: "raises an error if operation is not CREATE",
-			request: &admissionv1.AdmissionRequest{
-				Kind:      escalation.ExpectedKind,
-				Operation: admissionv1.Delete,
-			},
-			wantError: webhooksupport.ErrUnexpectedOperation,
-		},
-		{
 			desc: "denies if the policy is not known",
 			request: &admissionv1.AdmissionRequest{
-				Kind:      escalation.ExpectedKind,
-				Operation: admissionv1.Create,
 				Object: runtime.RawExtension{
 					Raw: webhooktesting.EncodeObject(
 						t,
@@ -139,8 +117,6 @@ func TestEscalationAdmissionReviewer_ReviewAdmission(t *testing.T) {
 		{
 			desc: "denies if the escalation has no reason",
 			request: &admissionv1.AdmissionRequest{
-				Kind:      escalation.ExpectedKind,
-				Operation: admissionv1.Create,
 				Object: runtime.RawExtension{
 					Raw: webhooktesting.EncodeObject(
 						t,
@@ -166,8 +142,6 @@ func TestEscalationAdmissionReviewer_ReviewAdmission(t *testing.T) {
 		{
 			desc: "denies if the user is not allowed to use the policy",
 			request: &admissionv1.AdmissionRequest{
-				Kind:      escalation.ExpectedKind,
-				Operation: admissionv1.Create,
 				Object: runtime.RawExtension{
 					Raw: webhooktesting.EncodeObject(
 						t,
@@ -194,8 +168,6 @@ func TestEscalationAdmissionReviewer_ReviewAdmission(t *testing.T) {
 		{
 			desc: "denies if the duration asked by the user exceeds the policy max duration",
 			request: &admissionv1.AdmissionRequest{
-				Kind:      escalation.ExpectedKind,
-				Operation: admissionv1.Create,
 				Object: runtime.RawExtension{
 					Raw: webhooktesting.EncodeObject(
 						t,
@@ -223,8 +195,6 @@ func TestEscalationAdmissionReviewer_ReviewAdmission(t *testing.T) {
 		{
 			desc: "denies if the refered policy has an unsupported grant kind",
 			request: &admissionv1.AdmissionRequest{
-				Kind:      escalation.ExpectedKind,
-				Operation: admissionv1.Create,
 				Object: runtime.RawExtension{
 					Raw: webhooktesting.EncodeObject(
 						t,
@@ -251,8 +221,6 @@ func TestEscalationAdmissionReviewer_ReviewAdmission(t *testing.T) {
 		{
 			desc: "denies if the escalation is not compatible with grant",
 			request: &admissionv1.AdmissionRequest{
-				Kind:      escalation.ExpectedKind,
-				Operation: admissionv1.Create,
 				Object: runtime.RawExtension{
 					Raw: webhooktesting.EncodeObject(
 						t,
@@ -280,8 +248,6 @@ func TestEscalationAdmissionReviewer_ReviewAdmission(t *testing.T) {
 		{
 			desc: "allows users by username",
 			request: &admissionv1.AdmissionRequest{
-				Kind:      escalation.ExpectedKind,
-				Operation: admissionv1.Create,
 				Object: runtime.RawExtension{
 					Raw: webhooktesting.EncodeObject(
 						t,
@@ -307,8 +273,6 @@ func TestEscalationAdmissionReviewer_ReviewAdmission(t *testing.T) {
 		{
 			desc: "allows users by group membership",
 			request: &admissionv1.AdmissionRequest{
-				Kind:      escalation.ExpectedKind,
-				Operation: admissionv1.Create,
 				Object: runtime.RawExtension{
 					Raw: webhooktesting.EncodeObject(
 						t,
@@ -352,7 +316,7 @@ func TestEscalationAdmissionReviewer_ReviewAdmission(t *testing.T) {
 					},
 				}
 
-				reviewer = escalation.NewAdmissionReviewer(
+				reviewer = escalation.NewCreateAdmissionReviewer(
 					escalationPolicyInformer.Lister(),
 					grant.StaticFactory{
 						testGrantKind: injectMockGranter(&dummyGranter),

--- a/escalation/webhook.go
+++ b/escalation/webhook.go
@@ -1,0 +1,29 @@
+package escalation
+
+import (
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+
+	"github.com/jlevesy/kudo/grant"
+	kudoinformers "github.com/jlevesy/kudo/pkg/generated/informers/externalversions"
+	"github.com/jlevesy/kudo/pkg/webhooksupport"
+)
+
+func SetupWebhook(router *http.ServeMux, kudoInformerFactory kudoinformers.SharedInformerFactory, granterFactory grant.Factory) {
+	reviewer := NewAdmissionReviewer(
+		kudoInformerFactory.K8s().V1alpha1().EscalationPolicies().Lister(),
+		granterFactory,
+	)
+
+	router.Handle(
+		"/v1alpha1/escalations",
+		webhooksupport.NewHandler(
+			webhooksupport.RouteAdmissionRequests(
+				webhooksupport.HandleOperation(
+					admissionv1.Create, reviewer,
+				),
+			),
+		),
+	)
+}

--- a/escalation/webhook.go
+++ b/escalation/webhook.go
@@ -4,24 +4,37 @@ import (
 	"net/http"
 
 	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/jlevesy/kudo/grant"
+	kudo "github.com/jlevesy/kudo/pkg/apis/k8s.kudo.dev"
+	kudov1alpha1 "github.com/jlevesy/kudo/pkg/apis/k8s.kudo.dev/v1alpha1"
 	kudoinformers "github.com/jlevesy/kudo/pkg/generated/informers/externalversions"
 	"github.com/jlevesy/kudo/pkg/webhooksupport"
 )
 
-func SetupWebhook(router *http.ServeMux, kudoInformerFactory kudoinformers.SharedInformerFactory, granterFactory grant.Factory) {
-	reviewer := NewAdmissionReviewer(
-		kudoInformerFactory.K8s().V1alpha1().EscalationPolicies().Lister(),
-		granterFactory,
-	)
+var (
+	expectedKind = metav1.GroupVersionKind{
+		Group:   kudo.GroupName,
+		Version: kudov1alpha1.Version,
+		Kind:    kudov1alpha1.KindEscalation,
+	}
+)
 
+func SetupWebhook(router *http.ServeMux, kudoInformerFactory kudoinformers.SharedInformerFactory, granterFactory grant.Factory) {
 	router.Handle(
 		"/v1alpha1/escalations",
 		webhooksupport.NewHandler(
-			webhooksupport.RouteAdmissionRequests(
-				webhooksupport.HandleOperation(
-					admissionv1.Create, reviewer,
+			webhooksupport.RequireKind(
+				expectedKind,
+				webhooksupport.RouteByOperation(
+					webhooksupport.HandleOperation(
+						admissionv1.Create,
+						NewCreateAdmissionReviewer(
+							kudoInformerFactory.K8s().V1alpha1().EscalationPolicies().Lister(),
+							granterFactory,
+						),
+					),
 				),
 			),
 		),

--- a/escalationpolicy/reviewer.go
+++ b/escalationpolicy/reviewer.go
@@ -8,36 +8,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
-	kudo "github.com/jlevesy/kudo/pkg/apis/k8s.kudo.dev"
 	kudov1alpha1 "github.com/jlevesy/kudo/pkg/apis/k8s.kudo.dev/v1alpha1"
 	"github.com/jlevesy/kudo/pkg/webhooksupport"
 )
 
-var (
-	expectedKind = metav1.GroupVersionKind{
-		Group:   kudo.GroupName,
-		Version: kudov1alpha1.Version,
-		Kind:    kudov1alpha1.KindEscalationPolicy,
-	}
-)
+type admissionReviewer struct{}
 
-type AdmissionReviewer struct{}
-
-func NewAdmissionReviewer() *AdmissionReviewer {
-	return &AdmissionReviewer{}
+func NewAdmissionReviewer() webhooksupport.AdmissionReviewer {
+	return &admissionReviewer{}
 }
 
-func (r *AdmissionReviewer) ReviewAdmission(ctx context.Context, req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
-	if req.Kind != expectedKind {
-		klog.Errorf(
-			"Received unexpected review kind %q for user %q",
-			req.Kind,
-			req.UserInfo.Username,
-		)
-
-		return nil, webhooksupport.ErrUnexpectedKind
-	}
-
+func (r *admissionReviewer) ReviewAdmission(ctx context.Context, req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
 	var policy kudov1alpha1.EscalationPolicy
 
 	if err := json.Unmarshal(req.Object.Raw, &policy); err != nil {

--- a/escalationpolicy/reviewer_test.go
+++ b/escalationpolicy/reviewer_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/jlevesy/kudo/escalationpolicy"
 	kudo "github.com/jlevesy/kudo/pkg/apis/k8s.kudo.dev"
 	kudov1alpha1 "github.com/jlevesy/kudo/pkg/apis/k8s.kudo.dev/v1alpha1"
-	"github.com/jlevesy/kudo/pkg/webhooksupport"
 	"github.com/jlevesy/kudo/pkg/webhooksupport/webhooktesting"
 )
 
@@ -24,17 +23,6 @@ func TestAdmissionRevierer_ReviewAdmission(t *testing.T) {
 		wantResp *admissionv1.AdmissionResponse
 		wantErr  error
 	}{
-		{
-			desc: "raises error if request has wrong kind",
-			req: &admissionv1.AdmissionRequest{
-				Kind: metav1.GroupVersionKind{
-					Group:   kudo.GroupName,
-					Version: kudov1alpha1.Version,
-					Kind:    kudov1alpha1.KindEscalation,
-				},
-			},
-			wantErr: webhooksupport.ErrUnexpectedKind,
-		},
 		{
 			desc: "denies if policy doesn't have a default duration",
 			req: &admissionv1.AdmissionRequest{

--- a/escalationpolicy/webhook.go
+++ b/escalationpolicy/webhook.go
@@ -3,14 +3,35 @@ package escalationpolicy
 import (
 	"net/http"
 
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kudo "github.com/jlevesy/kudo/pkg/apis/k8s.kudo.dev"
+	kudov1alpha1 "github.com/jlevesy/kudo/pkg/apis/k8s.kudo.dev/v1alpha1"
 	"github.com/jlevesy/kudo/pkg/webhooksupport"
 )
 
+var (
+	expectedKind = metav1.GroupVersionKind{
+		Group:   kudo.GroupName,
+		Version: kudov1alpha1.Version,
+		Kind:    kudov1alpha1.KindEscalationPolicy,
+	}
+)
+
 func SetupWebhook(router *http.ServeMux) {
+	reviewer := NewAdmissionReviewer()
+
 	router.Handle(
 		"/v1alpha1/escalationpolicies",
 		webhooksupport.NewHandler(
-			NewAdmissionReviewer(),
+			webhooksupport.RequireKind(
+				expectedKind,
+				webhooksupport.RouteByOperation(
+					webhooksupport.HandleOperation(admissionv1.Create, reviewer),
+					webhooksupport.HandleOperation(admissionv1.Update, reviewer),
+				),
+			),
 		),
 	)
 }

--- a/escalationpolicy/webhook.go
+++ b/escalationpolicy/webhook.go
@@ -1,0 +1,16 @@
+package escalationpolicy
+
+import (
+	"net/http"
+
+	"github.com/jlevesy/kudo/pkg/webhooksupport"
+)
+
+func SetupWebhook(router *http.ServeMux) {
+	router.Handle(
+		"/v1alpha1/escalationpolicies",
+		webhooksupport.NewHandler(
+			NewAdmissionReviewer(),
+		),
+	)
+}

--- a/helm/templates/webhook.yaml
+++ b/helm/templates/webhook.yaml
@@ -33,7 +33,7 @@ webhooks:
   rules:
   - apiGroups:   ["k8s.kudo.dev"]
     apiVersions: ["v1alpha1"]
-    operations:  ["CREATE"]
+    operations:  ["CREATE", "UPDATE", "DELETE", "CONNECT"]
     resources:   ["escalations"]
     scope:       "Cluster"
   clientConfig:

--- a/pkg/webhooksupport/handler.go
+++ b/pkg/webhooksupport/handler.go
@@ -2,17 +2,11 @@ package webhooksupport
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
-)
-
-var (
-	ErrUnexpectedKind      = errors.New("unexpected kind")
-	ErrUnexpectedOperation = errors.New("unexpected operation")
 )
 
 var (

--- a/pkg/webhooksupport/handler_test.go
+++ b/pkg/webhooksupport/handler_test.go
@@ -3,7 +3,6 @@ package webhooksupport_test
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -53,26 +52,6 @@ func TestWebhookHandler_ServeHTTP(t *testing.T) {
 			)),
 			wantStatus: http.StatusOK,
 			wantReview: &admissionv1.AdmissionReview{
-				Response: &admissionv1.AdmissionResponse{
-					Result: &metav1.Status{
-						Status:  metav1.StatusFailure,
-						Message: "Unexpected error, see controller logs for details",
-					},
-				},
-			},
-		},
-		{
-			desc: "complains if reviewer answers an error",
-			request: httptest.NewRequest(http.MethodPost, "/webhook", webhooktesting.EncodeObject(
-				t,
-				&admissionv1.AdmissionReview{
-					Request: &admissionv1.AdmissionRequest{},
-				},
-			)),
-			reviewerError: errors.New("hahaha"),
-			wantStatus:    http.StatusOK,
-			wantReview: &admissionv1.AdmissionReview{
-				Request: &admissionv1.AdmissionRequest{},
 				Response: &admissionv1.AdmissionResponse{
 					Result: &metav1.Status{
 						Status:  metav1.StatusFailure,

--- a/pkg/webhooksupport/reviewer.go
+++ b/pkg/webhooksupport/reviewer.go
@@ -9,3 +9,9 @@ import (
 type AdmissionReviewer interface {
 	ReviewAdmission(ctx context.Context, req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error)
 }
+
+type AdmissionReviewerFunc func(ctx context.Context, req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error)
+
+func (f AdmissionReviewerFunc) ReviewAdmission(ctx context.Context, req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
+	return f(ctx, req)
+}

--- a/pkg/webhooksupport/router.go
+++ b/pkg/webhooksupport/router.go
@@ -1,0 +1,98 @@
+package webhooksupport
+
+import (
+	"context"
+	"fmt"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+type OperationOption func(r *admissionReviewRouter)
+
+func DefaultReviewer(reviewer AdmissionReviewer) OperationOption {
+	return func(r *admissionReviewRouter) {
+		r.defaultReviewer = reviewer
+	}
+}
+
+func HandleOperation(op admissionv1.Operation, reviewer AdmissionReviewer) OperationOption {
+	return func(r *admissionReviewRouter) {
+		r.routes[op] = reviewer
+	}
+}
+
+func RouteByOperation(opts ...OperationOption) AdmissionReviewer {
+	router := admissionReviewRouter{
+		routes: make(map[admissionv1.Operation]AdmissionReviewer),
+		defaultReviewer: &denyReviewer{
+			reason: "Unsupported operation",
+		},
+	}
+
+	for _, opt := range opts {
+		opt(&router)
+	}
+
+	return &router
+}
+
+func RequireKind(want metav1.GroupVersionKind, next AdmissionReviewer) AdmissionReviewer {
+	return &requireKindReviewer{
+		wantKind: want,
+		next:     next,
+	}
+}
+
+type admissionReviewRouter struct {
+	routes          map[admissionv1.Operation]AdmissionReviewer
+	defaultReviewer AdmissionReviewer
+}
+
+func (a *admissionReviewRouter) ReviewAdmission(ctx context.Context, r *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
+	reviewer, ok := a.routes[r.Operation]
+	if !ok {
+		reviewer = a.defaultReviewer
+	}
+
+	return reviewer.ReviewAdmission(ctx, r)
+}
+
+type requireKindReviewer struct {
+	wantKind metav1.GroupVersionKind
+	next     AdmissionReviewer
+}
+
+func (r *requireKindReviewer) ReviewAdmission(ctx context.Context, req *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
+	if req.Kind != r.wantKind {
+		klog.Errorf(
+			"Received unexpected review kind %q for user %q",
+			req.Kind,
+			req.UserInfo.Username,
+		)
+
+		return &admissionv1.AdmissionResponse{
+			Result: &metav1.Status{
+				Status:  metav1.StatusFailure,
+				Message: fmt.Sprintf("Received unexpected kind %s", req.Kind.String()),
+			},
+		}, nil
+	}
+
+	return r.next.ReviewAdmission(ctx, req)
+
+}
+
+type denyReviewer struct {
+	reason string
+}
+
+func (d *denyReviewer) ReviewAdmission(ctx context.Context, r *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
+	return &admissionv1.AdmissionResponse{
+		Result: &metav1.Status{
+			Status:  metav1.StatusFailure,
+			Message: d.reason,
+		},
+	}, nil
+}

--- a/pkg/webhooksupport/router_test.go
+++ b/pkg/webhooksupport/router_test.go
@@ -1,0 +1,72 @@
+package webhooksupport_test
+
+import (
+	"context"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/jlevesy/kudo/pkg/webhooksupport"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRouteByOperation(t *testing.T) {
+	var (
+		createCalled bool
+
+		router = webhooksupport.RouteByOperation(
+			webhooksupport.HandleOperation(
+				admissionv1.Create,
+				webhooksupport.AdmissionReviewerFunc(func(context.Context, *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
+					createCalled = true
+					return &admissionv1.AdmissionResponse{}, nil
+				}),
+			),
+		)
+	)
+
+	_, _ = router.ReviewAdmission(context.Background(), &admissionv1.AdmissionRequest{Operation: admissionv1.Create})
+	assert.True(t, createCalled)
+
+	resp, _ := router.ReviewAdmission(context.Background(), &admissionv1.AdmissionRequest{Operation: admissionv1.Update})
+	assert.Equal(
+		t,
+		&admissionv1.AdmissionResponse{
+			Result: &metav1.Status{
+				Status:  metav1.StatusFailure,
+				Message: "Unsupported operation",
+			},
+		},
+		resp,
+	)
+}
+
+func TestRequireKind(t *testing.T) {
+	var (
+		createCalled bool
+
+		router = webhooksupport.RequireKind(
+			metav1.GroupVersionKind{Group: "test"},
+			webhooksupport.AdmissionReviewerFunc(func(context.Context, *admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
+				createCalled = true
+				return &admissionv1.AdmissionResponse{}, nil
+			}),
+		)
+	)
+
+	_, _ = router.ReviewAdmission(context.Background(), &admissionv1.AdmissionRequest{Kind: metav1.GroupVersionKind{Group: "test"}})
+	assert.True(t, createCalled)
+
+	resp, _ := router.ReviewAdmission(context.Background(), &admissionv1.AdmissionRequest{Kind: metav1.GroupVersionKind{Group: "pastest"}})
+	assert.Equal(
+		t,
+		&admissionv1.AdmissionResponse{
+			Result: &metav1.Status{
+				Status:  metav1.StatusFailure,
+				Message: "Received unexpected kind pastest/, Kind=",
+			},
+		},
+		resp,
+	)
+}


### PR DESCRIPTION
### What Does This PR do?

This PR introduces changes to the webhook handlers so that updating or deleting escalation is denied for anyone except the kudo service account.

I have introduced a way to require a kind for an admission request and a router by admission request operation to make the code cleaner.

Fixes: https://github.com/jlevesy/kudo/issues/11

### How to Test This PR?

```bash
make run_dev

make run_escalation_dev

# try to mutate the escalation, get your ass kicked
```

### Good PR Checklist

- [x] Addresses one issue
- [x] Adds/Updates unit tests
- [x] Adds/Updates e2e tests
- [ ] ~Adds/Updates the documentation~ not required.
- [x] Opened against the right branch
- [x] Correctly Labeled